### PR TITLE
Stop explicitly including NGINX stream module

### DIFF
--- a/docker/conf/nginx.conf
+++ b/docker/conf/nginx.conf
@@ -1,5 +1,3 @@
-load_module /usr/lib64/nginx/modules/ngx_stream_module.so;
-
 user nginx;
 worker_processes auto;
 pid /run/nginx.pid;


### PR DESCRIPTION
As the title says, this PR removes the explicit include for `/usr/lib64/nginx/modules/ngx_stream_module.so` in the NGINX config.

It seems that as of NGINX version 1.20, the stream module is baked in. This means that explicitly including it causes NGINX to die on start-up, as it can't locate the external stream module.