### PR TITLE
Add healthcheck endpoint for use with load balancer

### DIFF
--- a/docker/conf/nginx.conf
+++ b/docker/conf/nginx.conf
@@ -4,48 +4,48 @@ pid /run/nginx.pid;
 include /etc/nginx/modules-enabled/*.conf;
 
 events {
-	worker_connections 768;
+  worker_connections 768;
 }
 
 http {
-	sendfile on;
-	tcp_nopush on;
-	tcp_nodelay on;
-	keepalive_timeout 65;
-	types_hash_max_size 2048;
-	include /etc/nginx/mime.types;
-	default_type application/octet-stream;
-	ssl_protocols TLSv1.2; # Dropping SSLv3, ref: POODLE
-	ssl_prefer_server_ciphers on;
-	error_log     /dev/stdout info;
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+  keepalive_timeout 65;
+  types_hash_max_size 2048;
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+  ssl_protocols TLSv1.2; # Dropping SSLv3, ref: POODLE
+  ssl_prefer_server_ciphers on;
+  error_log     /dev/stdout info;
   access_log    /dev/stdout combined;
-	gzip on;
-	include /etc/nginx/conf.d/*.conf;
-	include /etc/nginx/sites-enabled/*;
+  gzip on;
+  include /etc/nginx/conf.d/*.conf;
+  include /etc/nginx/sites-enabled/*;
 
-	server {
-      listen                443 ssl;
-      ssl_certificate       /certs/server.crt;
-      ssl_certificate_key   /certs/server.key;
-      ssl_protocols         TLSv1.2;
-      ssl_ciphers           HIGH:!aNULL:!MD5;
+  server {
+    listen                443 ssl;
+    ssl_certificate       /certs/server.crt;
+    ssl_certificate_key   /certs/server.key;
+    ssl_protocols         TLSv1.2;
+    ssl_ciphers           HIGH:!aNULL:!MD5;
 
-      location / {
-        proxy_pass          http://localhost:3000;
-      }
-
-      location /elb-status {
-        access_log   off;
-        return       200;
-        add_header   Content-Type text/plain;
-      }
+    location / {
+      proxy_pass          http://localhost:3000;
     }
 
-    server {
-      listen        80 default_server;
-      server_name   _;
-      return        301 https://$host$request_uri;
-      error_log     /dev/stdout info;
-      access_log    /dev/stdout combined;
+    location /elb-status {
+      access_log   off;
+      return       200;
+      add_header   Content-Type text/plain;
     }
+  }
+
+  server {
+    listen        80 default_server;
+    server_name   _;
+    return        301 https://$host$request_uri;
+    error_log     /dev/stdout info;
+    access_log    /dev/stdout combined;
+  }
 }


### PR DESCRIPTION
This PR:

- Gets NGINX to serve a `/elb-status` endpoint for use with the load balancer health check
- Reformats the NGINX config to tidy up the mixed tabs/spaces and wonky indentation