### PR TITLE
Make sure inclusion/exclusion lists in tokens are consistent

### DIFF
--- a/src/lib/AuthenticationProvider/DatabaseAuthenticator.ts
+++ b/src/lib/AuthenticationProvider/DatabaseAuthenticator.ts
@@ -51,8 +51,8 @@ export default class DatabaseAuthenticator extends AuthenticationProvider {
 
     return {
       username: user.username,
-      exclusionList: user.exclusion_list,
-      inclusionList: user.inclusion_list,
+      exclusionList: user.exclusion_list.split(/[, ]/),
+      inclusionList: user.inclusion_list.split(/[, ]/),
       endorsedBy: user.endorsed_by,
       orgServes: user.org_serves,
       forenames: user.forenames,


### PR DESCRIPTION
The inclusion/exclusions lists are stored in the database as strings separated by commas _and_ whitespace.

The static authenticator returns tokens that have these lists as arrays, and the code in Bichard that decodes and handles the JWTs generated by the user-service expects them to be arrays.

This PR updates the database authenticator to make sure the `inclusionList` and `exclusionList` parameters in the tokens are arrays, not strings.