### PR TITLE
Make sure to strip '_grp' from group names that are fetched from DB

### DIFF
--- a/src/lib/AuthenticationProvider/DatabaseAuthenticator.ts
+++ b/src/lib/AuthenticationProvider/DatabaseAuthenticator.ts
@@ -78,7 +78,7 @@ export default class DatabaseAuthenticator extends AuthenticationProvider {
     `
 
     const res = await this.dbClient.query(query, [emailAddress])
-    const groups = res.rows.map((row) => row.name)
+    const groups = res.rows.map((row) => row.name.replace(/_grp$/, ""))
 
     return groups
   }


### PR DESCRIPTION
This again keeps things consistent with the static local user data, as well as bringing it in line with what the new Bichard `/Authenticate` endpoint expects in the token.