### PR TITLE
Build user-service docker image from nginx-nodejs-supervisord base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-ARG NODE_IMAGE="258361008057.dkr.ecr.eu-west-2.amazonaws.com/nodejs:latest"
+ARG BUILD_IMAGE="nginx-nodejs-supervisord"
 
 # Build user-service app
 
-FROM ${NODE_IMAGE} as app_builder
+FROM ${BUILD_IMAGE} as app_builder
 
 LABEL maintainer="CJSE"
 
@@ -17,32 +17,9 @@ COPY . ./
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build
 
-FROM ${NODE_IMAGE} as cert_generator
-
-WORKDIR /certs
-
-RUN yum update -y && \
-    yum install -y openssl
-
-RUN openssl req -newkey rsa:4096 \
-    -x509 \
-    -sha256 \
-    -days 3650 \
-    -nodes \
-    -out server.crt \
-    -keyout server.key \
-    -subj "/CN=localhost"
-
 # Run user-service app
 
-FROM ${NODE_IMAGE} as runner
-
-RUN yum update -y && \
-    amazon-linux-extras install -y epel && \
-    yum install -y \
-        supervisor \
-        nginx \
-        shadow-utils
+FROM ${BUILD_IMAGE} as runner
 
 RUN useradd nextjs
 RUN groupadd nodejs
@@ -58,8 +35,6 @@ RUN npm install --production --ignore-scripts
 COPY --from=app_builder /src/user-service/next.config.js ./
 COPY --from=app_builder /src/user-service/public ./public
 COPY --from=app_builder --chown=nextjs:nodejs /src/user-service/.next ./.next
-
-COPY --from=cert_generator /certs /certs
 
 COPY docker/conf/nginx.conf /etc/nginx/nginx.conf
 COPY docker/conf/supervisord.conf /etc/supervisord.conf

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -27,14 +27,14 @@ aws ecr get-login-password --region eu-west-2 | docker login \
 
 # Get our latest staged nodejs image
 IMAGE_HASH=$(aws ecr describe-images \
-    --repository-name nodejs \
+    --repository-name nginx-nodejs-supervisord \
     --query 'to_string(sort_by(imageDetails,& imagePushedAt)[-1].imageDigest)' \
     --output text
 )
 
-DOCKER_IMAGE_HASH="${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/nodejs@${IMAGE_HASH}"
+DOCKER_IMAGE_HASH="${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/nginx-nodejs-supervisord@${IMAGE_HASH}"
 
-docker build --build-arg "NODE_IMAGE=${DOCKER_IMAGE_HASH}" -t user-service .
+docker build --build-arg "BUILD_IMAGE=${DOCKER_IMAGE_HASH}" -t user-service .
 
 if [[ -n "${CODEBUILD_RESOLVED_SOURCE_VERSION}" && -n "${CODEBUILD_START_TIME}" ]]; then
     docker tag \


### PR DESCRIPTION
This is a small change to build the user-service docker image on top of the [`nginx-nodejs-supervisord`](https://github.com/ministryofjustice/bichard7-next-infrastructure-docker-images/tree/master/Nginx_NodeJS_Supervisord) docker image.

This new base image already installs nginx, supervisord, and generates a certificate for us for free - thus making the user-service image simpler.