### PR TITLE
Run integration tests and UI tests separately in the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,21 @@ jobs:
           name: Run unit tests
           command: npm run test:unit
 
-  ui_integration_test:
+  integration_test:
+    machine:
+      image: ubuntu-2004:202104-01
+      docker_layer_caching: true
+    working_directory: ~
+    steps:
+      - checkout_and_install
+      - attach_workspace:
+          at: .
+      - run_bichard_database
+      - run:
+          name: Run integration tests
+          command: npm run test:integration
+
+  ui_test:
     machine:
       image: ubuntu-2004:202104-01
       docker_layer_caching: true
@@ -81,18 +95,18 @@ jobs:
           path: ./cypress/videos
       - store_artifacts:
           path: ./cypress/screenshots
-      - run:
-          name: Run integration tests
-          command: npm run test:integration
 
 workflows:
   version: 2
   build-and-test:
     jobs:
       - build
-      - ui_integration_test:
+      - unit_test:
           requires:
             - build
-      - unit_test:
+      - integration_test:
+          requires:
+            - build
+      - ui_test:
           requires:
             - build


### PR DESCRIPTION
This is a PR to run the UI tests and the integration tests in separate jobs in Circle CI, rather than running them sequentially in one job.

The reasoning behind this is two-fold:

- It will make the CI faster
- If there is a failure, it will make it clearer whether that failure is in the UI tests or the integration tests