### PR TITLE
Update default authentication token timeout to 15 seconds, rather than 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The application makes use of the following environment variables to permit confi
 | `$DB_SSL`                        | `false`                                            | Whether to use SSL when connecting to the database                                         |
 | `$EMAIL_VERIFICATION_EXPIRES_IN` | `30`                                               | The number of minutes after which the email verification links will expire                 |
 | `$INCORRECT_DELAY`               | `10`                                               | The amount of time (in seconds) to wait between successive login attemps for the same user |
-| `$TOKEN_EXPIRES_IN`              | `"5 seconds"`                                      | The amount of time the tokens should be valid for after issuing                            |
+| `$TOKEN_EXPIRES_IN`              | `"15 seconds"`                                     | The amount of time the tokens should be valid for after issuing                            |
 | `$TOKEN_ISSUER`                  | `"Bichard"`                                        | The string to use as the token issuer (`iss`)                                              |
 | `$TOKEN_QUERY_PARAM_NAME`        | `"token"`                                          | The name to use for the token query parameter when redirecting to `$BICHARD_REDIRECT_URL`  |
 | `$TOKEN_SECRET`                  | `"OliverTwist"`                                    | The HMAC secret to use for signing the tokens                                              |

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -18,7 +18,7 @@ const config: UserServiceConfig = {
   bichardRedirectURL: process.env.BICHARD_REDIRECT_URL ?? "https://localhost:9443/bichard-ui/Authenticate",
   emailVerificationExpiresIn: parseInt(process.env.EMAIL_VERIFICATION_EXPIRY ?? "30", 10),
   incorrectDelay: parseInt(process.env.INCORRECT_DELAY ?? "10", 10),
-  tokenExpiresIn: process.env.TOKEN_EXPIRES_IN ?? "5 seconds",
+  tokenExpiresIn: process.env.TOKEN_EXPIRES_IN ?? "15 seconds",
   tokenIssuer: process.env.TOKEN_ISSUER ?? "Bichard",
   tokenQueryParamName: process.env.TOKEN_QUERY_PARAM_NAME ?? "token",
   tokenSecret: process.env.TOKEN_SECRET ?? "OliverTwist",


### PR DESCRIPTION
5 seconds is just a bit too inconvenient for development; it often takes more than 5 seconds to dismiss the self-signed certificate warnings when getting redirected to Bichard.