### PR TITLE
Move CSP-related HTTP headers from Next.js to NGINX config

### DIFF
--- a/docker/conf/nginx.conf
+++ b/docker/conf/nginx.conf
@@ -30,7 +30,12 @@ http {
     ssl_certificate_key   /certs/server.key;
     ssl_protocols         TLSv1.2;
     ssl_ciphers           HIGH:!aNULL:!MD5;
-    add_header            Strict-Transport-Security "max-age=31536000; includeSubDomains";
+
+    add_header X-Content-Type-Options "nosniff";
+    add_header Content-Security-Policy "default-src 'self'; frame-src 'self'; frame-ancestors 'self'; form-action 'self'";
+    add_header X-Content-Security-Policy "default-src 'self'; frame-src 'self'; frame-ancestors 'self'; form-action 'self'";
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+    add_header X-Frame-Options "SAMEORIGIN";
 
     location / {
       proxy_pass   http://localhost:3000;

--- a/next.config.js
+++ b/next.config.js
@@ -12,34 +12,5 @@ module.exports = {
         permanent: false
       }
     ]
-  },
-  async headers() {
-    return [
-      {
-        source: "/(.*)",
-        headers: [
-          {
-            key: "X-Content-Type-Options",
-            value: "nosniff"
-          },
-          {
-            key: "Content-Security-Policy",
-            value: "default-src 'self'; frame-src 'self'; frame-ancestors 'self'; form-action 'self'"
-          },
-          {
-            key: "X-Content-Security-Policy",
-            value: "default-src 'self'; frame-src 'self'; frame-ancestors 'self'; form-action 'self'"
-          },
-          {
-            key: "Strict-Transport-Security",
-            value: "max-age=31536000"
-          },
-          {
-            key: "X-Frame-Options",
-            value: "SAMEORIGIN"
-          }
-        ]
-      }
-    ]
   }
 }


### PR DESCRIPTION
The security policy set by one of these headers disallows inline styles (as recommended by the ZAP scans we've been running).

Unforunately this was interfering with running the dev server that's bundled with Next.js (i.e. `npm run dev`) as it works by injecting styles into the HTML tags via javascript.

Moving these security policy headers to Nginx mean that they will only take effect when running the Next.js application in "production" (i.e, in the docker container that puts it behind Nginx) - so they won't interfere with Next's dev server.