### PR TITLE
Remove form-action content-security-policy header from NGINX config

### DIFF
--- a/docker/conf/nginx.conf
+++ b/docker/conf/nginx.conf
@@ -32,8 +32,8 @@ http {
     ssl_ciphers           HIGH:!aNULL:!MD5;
 
     add_header X-Content-Type-Options "nosniff";
-    add_header Content-Security-Policy "default-src 'self'; frame-src 'self'; frame-ancestors 'self'; form-action 'self'";
-    add_header X-Content-Security-Policy "default-src 'self'; frame-src 'self'; frame-ancestors 'self'; form-action 'self'";
+    add_header Content-Security-Policy "default-src 'self'; frame-src 'self'; frame-ancestors 'self'";
+    add_header X-Content-Security-Policy "default-src 'self'; frame-src 'self'; frame-ancestors 'self'";
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
     add_header X-Frame-Options "SAMEORIGIN";
 


### PR DESCRIPTION
This is a temporary workaround to solve some issues we're having with the redirect to Bichard after a user has successfully logged in.

After successfully entering their credentials, the following happens:

1. The password entry form POSTs to the same page that is serving the form
2. The POST handler for the page checks the credentials and if they are correct, returns a 301 redirect to Bichard with the authentication JWT

Setting the `Content-Security-Policy: form-action 'self'` means that although the initial POST from the form is allowed (step 1), there is inconsistent behaviour surrounding the redirect served after the form submission (step 2). Specifically, Google Chrome blocks the redirect, whilst Firefox allows it.

Once we've completed the NGINX authentication changes and moved all services to behind the same hostname, both browsers should happily accept the redirect. Until then, we're removing this CSP header (despite the complaints it will generate from Zap) to allow the tests to still be able to happily login.