### PR TITLE
Add a 'safety check' to prevent sending emails to example.com addresses

### DIFF
--- a/src/lib/getEmailer.ts
+++ b/src/lib/getEmailer.ts
@@ -26,7 +26,12 @@ const getConsoleMailer = (): Emailer => ({
 
 let emailer: Emailer
 
-export default function getEmailer(): Emailer {
+export default function getEmailer(emailAddress: string): Emailer {
+  if (config.smtp.host !== "console" && emailAddress.match(/example\.com(\.cjsm\.net)?$/i)) {
+    console.error("Would have sent an actual email to an example.com email address! Printing to console instead.")
+    return getConsoleMailer()
+  }
+
   if (emailer) {
     return emailer
   }

--- a/src/useCases/sendPasswordChangedEmail.ts
+++ b/src/useCases/sendPasswordChangedEmail.ts
@@ -20,7 +20,7 @@ export default async (connection: Database, emailAddress: string): PromiseResult
 
   const emailContent = createPasswordChangedEmail(user)
 
-  const emailer = getEmailer()
+  const emailer = getEmailer(emailAddress)
   return emailer
     .sendMail({
       from: config.emailFrom,

--- a/src/useCases/sendPasswordResetEmail.ts
+++ b/src/useCases/sendPasswordResetEmail.ts
@@ -35,7 +35,7 @@ export default async (connection: Database, emailAddress: string): PromiseResult
 
   const email = createPasswordResetEmailResult
 
-  const emailer = getEmailer()
+  const emailer = getEmailer(emailAddress)
   return emailer
     .sendMail({
       from: config.emailFrom,

--- a/src/useCases/sendVerificationEmail.ts
+++ b/src/useCases/sendVerificationEmail.ts
@@ -22,7 +22,7 @@ export default async (connection: Database, emailAddress: string, redirectPath?:
 
   const emailContent = createVerificationEmailResult
 
-  const emailer = getEmailer()
+  const emailer = getEmailer(emailAddress)
   return emailer
     .sendMail({
       from: config.emailFrom,

--- a/src/useCases/setupNewUser.ts
+++ b/src/useCases/setupNewUser.ts
@@ -48,7 +48,7 @@ export default async (
   }
 
   const email = createNewUserEmailResult
-  const emailer = getEmailer()
+  const emailer = getEmailer(userCreateDetails.emailAddress)
 
   return emailer
     .sendMail({


### PR DESCRIPTION
As the title says.

If sending of email via SMTP is configured (i.e. the `$SMTP_HOST` environment variable is set), and we try to send an email to a user with an email address ending in `example.com` or `example.com.cjsm.net`, then don't send the email and instead:

- Print a warning message to the console
- Print the email message to the console