### PR TITLE
Add exception to login that adds/removes CJSM suffix for Made Tech emails

### DIFF
--- a/src/lib/cjsmSuffix.ts
+++ b/src/lib/cjsmSuffix.ts
@@ -1,12 +1,32 @@
+interface CjsmDomainException {
+  domain: string
+  cjsmDomain: string
+}
+
+const cjsmDomainExceptions: [CjsmDomainException] = [{ domain: "madetech.com", cjsmDomain: "madetech.cjsm.net" }]
+
 const addCjsmSuffix = (emailAddress: string): string => {
   if (emailAddress.match(/\.cjsm\.net$/i)) {
     return emailAddress
+  }
+
+  for (let i = 0; i < cjsmDomainExceptions.length; i++) {
+    const domainRegex = new RegExp(`${cjsmDomainExceptions[i].domain}$`, "i")
+    if (emailAddress.match(domainRegex)) {
+      return emailAddress.replace(domainRegex, cjsmDomainExceptions[i].cjsmDomain)
+    }
   }
 
   return `${emailAddress}.cjsm.net`
 }
 
 const removeCjsmSuffix = (emailAddress: string): string => {
+  for (let i = 0; i < cjsmDomainExceptions.length; i++) {
+    const cjsmRegex = new RegExp(`${cjsmDomainExceptions[i].cjsmDomain}$`, "i")
+    if (emailAddress.match(cjsmRegex)) {
+      return emailAddress.replace(cjsmRegex, cjsmDomainExceptions[i].domain)
+    }
+  }
   return emailAddress.replace(/\.cjsm\.net$/i, "")
 }
 

--- a/test/lib/cjsmSuffix.test.ts
+++ b/test/lib/cjsmSuffix.test.ts
@@ -9,6 +9,12 @@ describe("addCjsmSuffix()", () => {
   it("should not append .cjsm.net to an email address if it already ends in .cjsm.net", () => {
     expect(addCjsmSuffix("bichard01@example.com.cjsm.net")).toEqual("bichard01@example.com.cjsm.net")
     expect(addCjsmSuffix("SUPERVISOR@PNN.POLICE.UK.CJSM.NET")).toEqual("SUPERVISOR@PNN.POLICE.UK.CJSM.NET")
+    expect(addCjsmSuffix("test.user@madetech.cjsm.net")).toEqual("test.user@madetech.cjsm.net")
+  })
+
+  it("should replace the domain with a CJSM domain if it matches an exception", () => {
+    expect(addCjsmSuffix("test.user@madetech.com")).toEqual("test.user@madetech.cjsm.net")
+    expect(addCjsmSuffix("FOO.BAR@MADETECH.COM")).toEqual("FOO.BAR@madetech.cjsm.net")
   })
 })
 
@@ -21,5 +27,11 @@ describe("removeCjsmSuffix()", () => {
   it("should not alter email address if it does not end in .cjsm.net", () => {
     expect(removeCjsmSuffix("bichard01@example.com")).toEqual("bichard01@example.com")
     expect(removeCjsmSuffix("SUPERVISOR@PNN.POLICE.UK")).toEqual("SUPERVISOR@PNN.POLICE.UK")
+    expect(removeCjsmSuffix("test.user@madetech.com")).toEqual("test.user@madetech.com")
+  })
+
+  it("should replace the CJSM domain with a regular one if it matches an exception", () => {
+    expect(removeCjsmSuffix("test.user@madetech.cjsm.net")).toEqual("test.user@madetech.com")
+    expect(removeCjsmSuffix("FOO.BAR@MADETECH.CJSM.NET")).toEqual("FOO.BAR@madetech.com")
   })
 })


### PR DESCRIPTION
It's come to light that the logic of "just append `.cjsm.net` to the user's full email address" to get the user's CJSM address works for police users, but does not apply to CJSM webmail users (i.e. Made Tech staff).

This PR adds support for manually listing how to convert between domains/CJSM email domains that don't fit this logic, and lists `madetech.com` <=> `madetech.cjsm.net` as the single exception (so far).

Listing exceptions manually like this isn't the most ideal; but seeing as all of the regular users of Bichard are not CJSM webmail users, the regular logic can be used to convert their email addresses - and so the list of exceptions should be very small.