### PR TITLE
Make the 403 page return the correct error code and name it consistently

### DIFF
--- a/cypress/integration/403-page.spec.js
+++ b/cypress/integration/403-page.spec.js
@@ -1,0 +1,26 @@
+describe("403 - Access denied", () => {
+  it("should display the correct 403 page", () => {
+    cy.visit("/403", { failOnStatusCode: false })
+
+    cy.get("head title").should("have.text", "Access denied")
+    cy.get("h1.govuk-heading-xl").should("have.text", "Access denied")
+    cy.get("p.govuk-body:nth-child(2)").should("have.text", "You do not have permission to access this page.")
+    cy.get("p.govuk-body:nth-child(3)").should(
+      "have.text",
+      "We suggest that you return to the home page and choose an available service to you."
+    )
+    cy.get("p.govuk-body:nth-child(4)").should(
+      "have.text",
+      "If you believe you have permission to access this page, you can contact support to report this issue."
+    )
+  })
+
+  it("should respond with correct HTTP status code (404)", () => {
+    cy.request({
+      failOnStatusCode: false,
+      url: "/403"
+    }).then((response) => {
+      expect(response.status).to.eq(403)
+    })
+  })
+})

--- a/src/pages/403.tsx
+++ b/src/pages/403.tsx
@@ -1,0 +1,38 @@
+import { GetServerSidePropsContext } from "next"
+import GridRow from "components/GridRow"
+import Layout from "components/Layout"
+import Link from "components/Link"
+import config from "lib/config"
+import Head from "next/head"
+
+export const getServerSideProps = ({ res }: GetServerSidePropsContext) => {
+  res.statusCode = 403
+  return {}
+}
+
+const AccessDenied = () => (
+  <>
+    <Head>
+      <title>{"Access denied"}</title>
+    </Head>
+    <Layout>
+      <GridRow>
+        <h1 className="govuk-heading-xl">{"Access denied"}</h1>
+
+        <p className="govuk-body">{"You do not have permission to access this page."}</p>
+        <p className="govuk-body">
+          {"We suggest that you return to the "}
+          <Link href="/">{"home page"}</Link>
+          {" and choose an available service to you."}
+        </p>
+        <p className="govuk-body">
+          {"If you believe you have permission to access this page, you can "}
+          <Link href={config.contactUrl}>{"contact support"}</Link>
+          {" to report this issue."}
+        </p>
+      </GridRow>
+    </Layout>
+  </>
+)
+
+export default AccessDenied

--- a/test/pages/403.test.tsx
+++ b/test/pages/403.test.tsx
@@ -1,0 +1,8 @@
+import { render } from "@testing-library/react"
+import AccessDenied from "pages/403"
+
+it("should render the component and match the snapshot", () => {
+  const { container } = render(<AccessDenied />)
+
+  expect(container).toMatchSnapshot()
+})


### PR DESCRIPTION
This is just to make the Nginx routes a bit cleaner since this page was inconsistently named compared to 404 and 500 pages. I've left the old page in until Nginx is updated