### PR TITLE
ci: 🎡 scan docker images on build

### DIFF
--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -46,24 +46,37 @@ if [[ -n "${CODEBUILD_RESOLVED_SOURCE_VERSION}" && -n "${CODEBUILD_START_TIME}" 
 
     export GOSS_PATH="/usr/local/bin/goss"
 
-    get_latest_release() {
-      curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
-        grep '"tag_name":' |                                            # Get tag line
-        sed -E 's/.*"([^"]+)".*/\1/'                                    # Pluck JSON value
-    }
-
     install_trivy() {
+      echo "Pulling trivy binary from s3"
+      aws s3 cp \
+        s3://"${S3_BUCKET}"/trivy/binary/trivy_latest_Linux-64bit.rpm \
+        .
+
       echo "Installing trivy binary"
-      TRIVY_VERSION=$(get_latest_release "aquasecurity/trivy" | sed 's/v//')
-      yum install -y https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.rpm
+      rpm -ivh trivy_latest_Linux-64bit.rpm
     }
 
+    pull_trivy_db() {
+      echo "Pulling trivy db from s3..."
+      aws s3 cp \
+        s3://"${S3_BUCKET}"/trivy/db/trivy-offline.db.tgz \
+        trivy/db/
+
+      echo "Extracting trivy db to `pwd`/trivy/db/"
+      tar -xvf trivy/db/trivy-offline.db.tgz -C trivy/db/
+    }
+  
+    mkdir -p trivy/db
     install_trivy
+    pull_trivy_db
 
     ## Run goss tests
     GOSS_SLEEP=15 dgoss run -e DB_HOST=172.17.0.1 "user-service:latest"
     ## Run Trivy scan
-    trivy image "user-service:latest"
+    TRIVY_CACHE_DIR=trivy trivy image \
+      --exit-code 1 \
+      --severity "CRITICAL" \
+      --skip-update "user-service:latest" # we have the most recent db pulled locally
 
     docker tag \
         user-service:latest \


### PR DESCRIPTION
Pull trivy (db and binary) from our s3 bucket and then scan the built docker image.