### PR TITLE
Restrict user details/edit/delete pages to users of the same force

### DIFF
--- a/cypress/integration/delete-user.spec.js
+++ b/cypress/integration/delete-user.spec.js
@@ -5,6 +5,7 @@ describe("Delete user", () => {
   })
 
   it("should delete the user when confirmation text is valid", () => {
+    cy.login("bichard01@example.com", "password")
     cy.visit("/users/Bichard02")
     cy.get('a[data-test="delete-user-view"]').click()
     cy.get("h1").contains("Are you sure you want to delete Bichard User 02 Surname 02?")
@@ -15,6 +16,7 @@ describe("Delete user", () => {
   })
 
   it("should not allow deleting the user when confirmation text is invalid", () => {
+    cy.login("bichard01@example.com", "password")
     cy.visit("/users/Bichard02")
     cy.get('a[data-test="delete-user-view"]').click()
     cy.get("h1").contains("Are you sure you want to delete Bichard User 02 Surname 02?")
@@ -26,6 +28,7 @@ describe("Delete user", () => {
   })
 
   it("should not allow deleting the user when confirmation text is empty", () => {
+    cy.login("bichard01@example.com", "password")
     cy.visit("/users/Bichard02")
     cy.get('a[data-test="delete-user-view"]').click()
     cy.get("h1").contains("Are you sure you want to delete Bichard User 02 Surname 02?")
@@ -33,6 +36,21 @@ describe("Delete user", () => {
     cy.get('[data-test="error-summary"]').contains("Username mismatch")
     cy.get('[data-test="error-summary"]').contains("Enter the account username")
     cy.url().should("contains", "/users/Bichard02/delete")
+  })
+
+  it("should not allow deleting a user outside of the current user's force", () => {
+    // Given
+    cy.login("bichard02@example.com", "password")
+
+    // When
+    cy.visit("/users/Bichard03", { failOnStatusCode: false })
+
+    // Then
+    cy.get("body").should("not.contain.text", "Are you sure you want to delete")
+    cy.get("body").should("not.contain.text", "Bichard03")
+    cy.get("body").should("not.contain.text", "Bichard User 03")
+    cy.get("body").should("not.contain.text", "Surname 03")
+    cy.get("body").should("contain.text", "Page not found")
   })
 
   it("should respond with forbidden response code when CSRF tokens are invalid in delete page", (done) => {

--- a/cypress/integration/edit-user.spec.js
+++ b/cypress/integration/edit-user.spec.js
@@ -46,6 +46,22 @@ describe("Edit user", () => {
     })
   })
 
+  it("should not allow a user to view another user outside of their force", () => {
+    // Given
+    cy.login("bichard02@example.com", "password")
+
+    // When
+    cy.visit("/users/Bichard03", { failOnStatusCode: false })
+
+    // Then
+    cy.get("body").should("not.contain.text", "User Details")
+    cy.get("body").should("not.contain.text", "Bichard03")
+    cy.get("body").should("not.contain.text", "Bichard User 03")
+    cy.get("body").should("not.contain.text", "Surname 03")
+    cy.get("body").should("not.contain.text", "bichard03@example.com")
+    cy.get("body").should("contain.text", "Page not found")
+  })
+
   it("should not be able to update user such that they are left without a force", () => {
     // Given
     cy.login("bichard02@example.com", "password")

--- a/cypress/integration/edit-user.spec.js
+++ b/cypress/integration/edit-user.spec.js
@@ -62,6 +62,21 @@ describe("Edit user", () => {
     cy.get("body").should("contain.text", "Page not found")
   })
 
+  it("should not allow a user to edit another user outside of their force", () => {
+    // Given
+    cy.login("bichard02@example.com", "password")
+
+    // When
+    cy.visit("/users/Bichard03/edit", { failOnStatusCode: false })
+
+    // Then
+    cy.get("body").should("not.contain.text", "Edit Bichard03's details")
+    cy.get("body").should("not.contain.text", "Bichard03")
+    cy.get("body").should("not.contain.text", "bichard03@example.com")
+    cy.get('input[id="username"]').should("not.exist")
+    cy.get("body").should("contain.text", "Page not found")
+  })
+
   it("should not be able to update user such that they are left without a force", () => {
     // Given
     cy.login("bichard02@example.com", "password")

--- a/src/lib/usersHaveSameForce.ts
+++ b/src/lib/usersHaveSameForce.ts
@@ -1,0 +1,7 @@
+import User from "types/User"
+
+export default function usersHaveSameForce(user1: Partial<User>, user2: Partial<User>): boolean {
+  const user1Forces = user1.visibleForces?.split(",") ?? []
+  const user2Forces = user2.visibleForces?.split(",") ?? []
+  return user1Forces.some((force: string) => user2Forces.includes(force))
+}

--- a/test/lib/usersHaveSameForce.test.ts
+++ b/test/lib/usersHaveSameForce.test.ts
@@ -1,0 +1,38 @@
+import usersHaveSameForce from "lib/usersHaveSameForce"
+
+describe("usersHaveSameForce()", () => {
+  it("should return true when the given users are both only in the same force", () => {
+    const user1 = { visibleForces: "001" }
+    const user2 = { visibleForces: "001" }
+    expect(usersHaveSameForce(user1, user2)).toBe(true)
+    expect(usersHaveSameForce(user2, user1)).toBe(true)
+  })
+
+  it("should return true when the given users have a single force in common", () => {
+    const user1 = { visibleForces: "001,002" }
+    const user2 = { visibleForces: "001,003" }
+    expect(usersHaveSameForce(user1, user2)).toBe(true)
+    expect(usersHaveSameForce(user2, user1)).toBe(true)
+  })
+
+  it("should return false when the given users have no forces in common", () => {
+    const user1 = { visibleForces: "001,002" }
+    const user2 = { visibleForces: "003,004" }
+    expect(usersHaveSameForce(user1, user2)).toBe(false)
+    expect(usersHaveSameForce(user2, user1)).toBe(false)
+  })
+
+  it("should return false when either of the given users have an empty force list", () => {
+    const user1 = { visibleForces: "" }
+    const user2 = { visibleForces: "001" }
+    expect(usersHaveSameForce(user1, user2)).toBe(false)
+    expect(usersHaveSameForce(user2, user1)).toBe(false)
+  })
+
+  it("should return false when either of the given users have no force list", () => {
+    const user1 = {}
+    const user2 = { visibleForces: "001" }
+    expect(usersHaveSameForce(user1, user2)).toBe(false)
+    expect(usersHaveSameForce(user2, user1)).toBe(false)
+  })
+})


### PR DESCRIPTION
This PR restricts the user details (`/user/<username>`), user edit (`/user/<username>/edit`) and user deletion (`/user/<username>/delete`) pages so that they are only visible to users that have at least one entry in their `visibleForces` in common with the user in question.

In other words, for user A to be able to edit the details or user B, user A and user B must both have the same force code listed in their `visibleForces`. If they do not, then user A will instead get served a 404 page.