### PR TITLE
fix: 🐛 use the latest image hash (don't error when 2 returned)

### DIFF
--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -29,7 +29,8 @@ aws ecr get-login-password --region eu-west-2 | docker login \
 IMAGE_HASH=$(aws ecr describe-images \
     --repository-name nginx-nodejs-supervisord \
     --query 'to_string(sort_by(imageDetails,& imagePushedAt)[-1].imageDigest)' \
-    --output text
+    --output text |
+    head -n 1
 )
 
 DOCKER_IMAGE_HASH="${AWS_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/nginx-nodejs-supervisord@${IMAGE_HASH}"


### PR DESCRIPTION
`aws ecr describe-images` is returning multiple hashes, which then errors when we try to pass that to docker. Only use the latest hash.