### PR TITLE
Allow user email addresses to be edited

### DIFF
--- a/cypress/integration/edit-user.spec.js
+++ b/cypress/integration/edit-user.spec.js
@@ -155,7 +155,6 @@ describe("Edit user", () => {
   it("should have the email and username text input fields readonly", () => {
     cy.login("bichard02@example.com", "password")
     cy.visit("users/Bichard02/edit")
-    cy.get('input[value="bichard02@example.com"]').invoke("attr", "readonly").should("eq", "readonly")
     cy.get('input[value="Bichard02"]').invoke("attr", "readonly").should("eq", "readonly")
   })
 

--- a/src/components/users/UserForm.tsx
+++ b/src/components/users/UserForm.tsx
@@ -80,7 +80,6 @@ const UserForm = ({
         type="email"
         value={emailAddress}
         error={emailError}
-        readOnly={isEdit}
         width="20"
         mandatory
       />

--- a/src/emails/EmailLayout.tsx
+++ b/src/emails/EmailLayout.tsx
@@ -87,8 +87,8 @@ const EmailBase = ({ children, title }: EmailBaseProps) => (
 )
 
 interface EmailLayoutProps {
-  actionUrl: string
-  buttonLabel: string
+  actionUrl?: string
+  buttonLabel?: string
   paragraphs: string[]
   title: string
 }
@@ -102,16 +102,20 @@ const EmailLayout = ({ actionUrl, buttonLabel, paragraphs, title }: EmailLayoutP
       <Paragraph key={i}>{paragraph}</Paragraph>
     ))}
 
-    <Button href={actionUrl} label={buttonLabel} />
+    {!!actionUrl && !!buttonLabel && (
+      <>
+        <Button href={actionUrl} label={buttonLabel} />
 
-    <p style={{ ...dimStyles, marginTop: "50px" }}>
-      {"If you’re having trouble clicking the button, copy and paste the URL below into your web browser:"}
-    </p>
-    <p style={{ ...dimStyles, margin: "0" }}>
-      <a href={actionUrl} style={dimStyles}>
-        {actionUrl}
-      </a>
-    </p>
+        <p style={{ ...dimStyles, marginTop: "50px" }}>
+          {"If you’re having trouble clicking the button, copy and paste the URL below into your web browser:"}
+        </p>
+        <p style={{ ...dimStyles, margin: "0" }}>
+          <a href={actionUrl} style={dimStyles}>
+            {actionUrl}
+          </a>
+        </p>
+      </>
+    )}
   </EmailBase>
 )
 

--- a/src/emails/emailChanged.tsx
+++ b/src/emails/emailChanged.tsx
@@ -1,11 +1,13 @@
 import ReactDOMServer from "react-dom/server"
 import EmailContent from "types/EmailContent"
+import User from "types/User"
 import EmailLayout from "./EmailLayout"
 
 type Status = "old" | "new"
 
 interface Props {
   status: Status
+  user: Pick<User, "forenames" | "surname">
 }
 
 const statusMessage = (status: Status) =>
@@ -13,11 +15,11 @@ const statusMessage = (status: Status) =>
     ? "You will no longer be able to sign in to Bichard with this email address."
     : "You will now need to use this email address to sign in to Bichard."
 
-const EmailChangedEmail = ({ status }: Props): JSX.Element => {
+const EmailChangedEmail = ({ status, user }: Props): JSX.Element => {
   return (
     <EmailLayout
       paragraphs={[
-        "Hi,",
+        `Hi, ${user.forenames} ${user.surname}`,
         "The email address associated with your Bichard account has been changed successfully.",
         statusMessage(status)
       ]}
@@ -26,8 +28,8 @@ const EmailChangedEmail = ({ status }: Props): JSX.Element => {
   )
 }
 
-const EmailChangedText = ({ status }: Props): string =>
-  `Hi,
+const EmailChangedText = ({ status, user }: Props): string =>
+  `Hi, ${user.forenames} ${user.surname}
 
 The email address associated with your Bichard account has been changed successfully.
 

--- a/src/emails/emailChanged.tsx
+++ b/src/emails/emailChanged.tsx
@@ -1,0 +1,46 @@
+import ReactDOMServer from "react-dom/server"
+import EmailContent from "types/EmailContent"
+import EmailLayout from "./EmailLayout"
+
+type Status = "old" | "new"
+
+interface Props {
+  status: Status
+}
+
+const statusMessage = (status: Status) =>
+  status === "old"
+    ? "You will no longer be able to sign in to Bichard with this email address."
+    : "You will now need to use this email address to sign in to Bichard."
+
+const EmailChangedEmail = ({ status }: Props): JSX.Element => {
+  return (
+    <EmailLayout
+      paragraphs={[
+        "Hi,",
+        "The email address associated with your Bichard account has been changed successfully.",
+        statusMessage(status)
+      ]}
+      title={"Bichard password changed"}
+    />
+  )
+}
+
+const EmailChangedText = ({ status }: Props): string =>
+  `Hi,
+
+The email address associated with your Bichard account has been changed successfully.
+
+${statusMessage(status)}
+`
+
+export default function generateEmailChangedEmail(props: Props): EmailContent {
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  const htmlEmail = <EmailChangedEmail {...props} />
+
+  return {
+    subject: "Bichard password changed",
+    html: ReactDOMServer.renderToStaticMarkup(htmlEmail),
+    text: EmailChangedText(props)
+  }
+}

--- a/src/lib/userFormIsValid.ts
+++ b/src/lib/userFormIsValid.ts
@@ -16,14 +16,14 @@ const userFormIsValid = (
 ): ValidationResult => {
   const validationResult = {
     forenamesError: !forenames?.trim() && "Enter the user's forename(s)",
-    surnameError: !surname?.trim() && "Enter the user's surname"
+    surnameError: !surname?.trim() && "Enter the user's surname",
+    emailError:
+      (!emailAddress?.trim() && "Enter the user's email address") ||
+      (!!emailAddress?.match(/\.cjsm\.net$/i) && "The user's email address should not end with .cjsm.net")
   } as ValidationResult
 
   if (!isEdit) {
     validationResult.usernameError = !username?.trim() && "Enter a username for the new user"
-    validationResult.emailError =
-      (!emailAddress?.trim() && "Enter the user's email address") ||
-      (!!emailAddress?.match(/\.cjsm\.net$/i) && "The user's email address should not end with .cjsm.net")
   }
 
   validationResult.isFormValid =

--- a/src/pages/users/[username]/edit.tsx
+++ b/src/pages/users/[username]/edit.tsx
@@ -129,7 +129,7 @@ export const getServerSideProps = withMultipleServerSideProps(
         }
 
         if (oldEmail !== newEmail) {
-          sendEmailChangedEmails(oldEmail, newEmail)
+          sendEmailChangedEmails(userDetails as { forenames: string; surname: string }, oldEmail, newEmail)
         }
 
         const updatedUser = await getUserById(connection, userDetails.id as number)

--- a/src/useCases/sendEmailChangedEmails.ts
+++ b/src/useCases/sendEmailChangedEmails.ts
@@ -3,10 +3,15 @@ import { addCjsmSuffix } from "lib/cjsmSuffix"
 import config from "lib/config"
 import getEmailer from "lib/getEmailer"
 import PromiseResult from "types/PromiseResult"
+import User from "types/User"
 
-export default async (oldEmail: string, newEmail: string): PromiseResult<void> => {
-  const oldEmailContent = generateEmailChangedEmail({ status: "old" })
-  const newEmailContent = generateEmailChangedEmail({ status: "new" })
+export default async (
+  user: Pick<User, "forenames" | "surname">,
+  oldEmail: string,
+  newEmail: string
+): PromiseResult<void> => {
+  const oldEmailContent = generateEmailChangedEmail({ status: "old", user })
+  const newEmailContent = generateEmailChangedEmail({ status: "new", user })
 
   let sendingError: Error | undefined
 

--- a/src/useCases/sendEmailChangedEmails.ts
+++ b/src/useCases/sendEmailChangedEmails.ts
@@ -1,0 +1,38 @@
+import generateEmailChangedEmail from "emails/emailChanged"
+import { addCjsmSuffix } from "lib/cjsmSuffix"
+import config from "lib/config"
+import getEmailer from "lib/getEmailer"
+import PromiseResult from "types/PromiseResult"
+
+export default async (oldEmail: string, newEmail: string): PromiseResult<void> => {
+  const oldEmailContent = generateEmailChangedEmail({ status: "old" })
+  const newEmailContent = generateEmailChangedEmail({ status: "new" })
+
+  let sendingError: Error | undefined
+
+  await getEmailer(oldEmail)
+    .sendMail({
+      from: config.emailFrom,
+      to: addCjsmSuffix(oldEmail),
+      ...oldEmailContent
+    })
+    .then(() => console.log(`Email successfully sent to ${oldEmail}`))
+    .catch((error: Error) => {
+      console.error(`Error sending email to ${oldEmail}`, error.message)
+      sendingError = error
+    })
+
+  await getEmailer(newEmail)
+    .sendMail({
+      from: config.emailFrom,
+      to: addCjsmSuffix(newEmail),
+      ...newEmailContent
+    })
+    .then(() => console.log(`Email successfully sent to ${newEmail}`))
+    .catch((error: Error) => {
+      console.error(`Error sending email to ${newEmail}`, error.message)
+      sendingError = error
+    })
+
+  return sendingError
+}

--- a/src/useCases/updateUser.ts
+++ b/src/useCases/updateUser.ts
@@ -53,6 +53,7 @@ const updateUserTable = async (task: ITask<unknown>, userDetails: Partial<User>)
 	    SET
         forenames=$\{forenames\},
         surname=$\{surname\},
+        email=$\{emailAddress\},
         endorsed_by=$\{endorsedBy\},
         org_serves=$\{orgServes\},
         visible_courts=$\{visibleCourts\},

--- a/test/useCases/updateUser.integration.test.ts
+++ b/test/useCases/updateUser.integration.test.ts
@@ -72,7 +72,7 @@ describe("updatePassword", () => {
     const user = {
       id: initialUser.id,
       username: "Bichard04",
-      email: "bichard04@example.com",
+      emailAddress: initialUser.email,
       forenames: "forename04",
       surname: "surname04",
       endorsedBy: "endorsed by 04",
@@ -100,13 +100,14 @@ describe("updatePassword", () => {
     expect(initialUser02.excluded_triggers).toBe("TRPR0002,")
   })
 
-  it("should not update emailAddress if provided in user object", async () => {
+  it("should update emailAddress if provided in user object", async () => {
     await insertIntoUsersTable(users)
     await insertIntoGroupsTable(groups)
     await insertIntoUserGroupsTable(
       "bichard01@example.com",
       groups.map((g) => g.name)
     )
+    const updatedEmail = "bichard04@example.com"
     const currentUserId = (await selectFromTable("users", "username", "Bichard01"))[0].id
 
     await insertUserWithGroup()
@@ -124,7 +125,7 @@ describe("updatePassword", () => {
       surname: "surname04A",
       endorsedBy: "endorsed by 04",
       orgServes: "orgAServes 04",
-      emailAddress: "bichard04@example.com",
+      emailAddress: updatedEmail,
       groups: [initialGroup],
       visibleForces: "004,007,",
       visibleCourts: "B02,",
@@ -133,10 +134,10 @@ describe("updatePassword", () => {
 
     const result = await updateUser(connection, fakeAuditLogger, currentUserId, user)
     expect(result).toBeUndefined()
-    const initialUserList02 = await selectFromTable("users", "email", emailAddress)
+    const initialUserList02 = await selectFromTable("users", "email", updatedEmail)
     const initialUser02 = initialUserList02[0]
 
-    expect(initialUser02.email).toBe(emailAddress)
+    expect(initialUser02.email).toBe(updatedEmail)
   })
 
   it("should throw the correct error if user is not found", async () => {
@@ -155,6 +156,7 @@ describe("updatePassword", () => {
 
     const user = {
       id: 0,
+      emailAddress: "bichard01@example.com",
       username: "Bichard04",
       forenames: "forename04",
       surname: "surname04A",
@@ -208,6 +210,7 @@ describe("updatePassword", () => {
 
     const updateUserDetails: any = {
       id: initialUser.id,
+      emailAddress: user.email,
       username: "new-username-01",
       forenames: "new-forenames-01",
       surname: "new-surname-01",
@@ -272,6 +275,7 @@ describe("updatePassword", () => {
 
     const updateUserDetails: any = {
       id: initialUser.id,
+      emailAddress: initialUser.email,
       username: "new-username-01",
       forenames: "new-forenames-01",
       surname: "new-surname-01",
@@ -325,6 +329,7 @@ describe("updatePassword", () => {
 
     const updateUserDetails = {
       id: initialUser.id,
+      emailAddress: user.email,
       username: "new-username-01",
       forenames: "new-forenames-01",
       surname: "new-surname-01",
@@ -360,6 +365,7 @@ describe("updatePassword", () => {
 
     const updateUserDetails: any = {
       id: initialUser.id,
+      emailAddress: "bichard1@example.com",
       username: "new-username-01",
       forenames: "new-forenames-01",
       surname: "new-surname-01",


### PR DESCRIPTION
This PR:

- Allows user managers to edit the email addresses for both themselves and the users they manage
- Checks to make sure the email address being changed to doesn't already belong to another user, and displays an appropriate error message if it does
- Upon successful change of email address, it sends notification emails to both the old and new email addresses informing them of the change