### PR TITLE
Make email change case insensitive

### DIFF
--- a/src/pages/users/[username]/edit.tsx
+++ b/src/pages/users/[username]/edit.tsx
@@ -88,8 +88,8 @@ export const getServerSideProps = withMultipleServerSideProps(
         const groupsChecked = groups.filter((group) => formData[group.name] === "yes")
         userDetails.groups = groupsChecked
 
-        const oldEmail = user.emailAddress
-        const newEmail = userDetails.emailAddress as string
+        const oldEmail = user.emailAddress.toLowerCase()
+        const newEmail = (userDetails.emailAddress as string).toLowerCase()
 
         if (oldEmail !== newEmail) {
           const existingUser = await getUserByEmailAddress(connection, newEmail)

--- a/src/useCases/getUserByEmailAddress.ts
+++ b/src/useCases/getUserByEmailAddress.ts
@@ -16,7 +16,8 @@ export default (db: Database, emailAddress: string): PromiseResult<User | null> 
         visible_forces AS "visibleForces",
         excluded_triggers AS "excludedTriggers"
       FROM br7own.users
-      WHERE email = $1 AND deleted_at IS NULL
+      WHERE LOWER(email) = LOWER($1)
+        AND deleted_at IS NULL
     `
   return db.oneOrNone<User>(query, [emailAddress]).catch((error) => error)
 }


### PR DESCRIPTION
This PR:

- Makes the logic to determine whether a user has changed their email address (and thus whether to send them an email) ignore case
- Makes the `getUserByEmailAddress()` function, used in a few places including authentication, ignore case too