### PR TITLE
Configure the contact URL to be the ServiceNow homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ The application makes use of the following environment variables to permit confi
 | `$AUDIT_LOGGING_URL`             | `"/audit-logging"`                 | The URL to redirect to audit logging                                                                 |
 | `$BASE_URL`                      | `"http://localhost:3000"`          | The URL that the user-service is being served from. Used for generating email links.                 |
 | `$BICHARD_REDIRECT_URL`          | `"/bichard-ui/InitialRefreshList"` | The URL to redirect to with a token as a GET parameter when authentication is successful             |
-| `$CONTACT_URL`                   | `"/contact-us"`                    | The URL to contact the support team                                                                  |
 | `$COOKIE_SECRET`                 | `"OliverTwist"`                    | The secret to use for signing the cookies                                                            |
 | `$COOKIES_SECURE`                | `true`                             | Whether to enable the `Secure` cookie flag (prevents cookies from being sent in non-https requests)  |
 | `$CSRF_COOKIE_SECRET`            | `"OliverTwist2"`                   | The secret to use for signing the CSRF cookie token                                                  |

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -55,7 +55,7 @@ const config: UserServiceConfig = {
   authenticationCookieName: ".AUTH",
   baseUrl: process.env.BASE_URL,
   bichardRedirectURL: process.env.BICHARD_REDIRECT_URL ?? "/bichard-ui/InitialRefreshList",
-  contactUrl: process.env.CONTACT_URL ?? "/contact-us",
+  contactUrl: "https://mojprod.service-now.com/",
   cookieSecret: process.env.COOKIE_SECRET ?? "OliverTwist",
   cookiesSecureOption: (process.env.COOKIES_SECURE ?? "true") === "true",
   debugMode: "false",

--- a/test/components/__snapshots__/NotReceivedEmail.test.tsx.snap
+++ b/test/components/__snapshots__/NotReceivedEmail.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`should render the component and match the snapshot 1`] = `
         If you no longer have access to your email address you will need to 
         <a
           class="govuk-link"
-          href="/contact-us"
+          href="https://mojprod.service-now.com/"
         >
           contact us
         </a>

--- a/test/pages/__snapshots__/403.test.tsx.snap
+++ b/test/pages/__snapshots__/403.test.tsx.snap
@@ -105,7 +105,7 @@ exports[`should render the component and match the snapshot 1`] = `
             If you believe you have permission to access this page, you can 
             <a
               class="govuk-link"
-              href="/contact-us"
+              href="https://mojprod.service-now.com/"
             >
               contact support
             </a>

--- a/test/pages/__snapshots__/500.test.tsx.snap
+++ b/test/pages/__snapshots__/500.test.tsx.snap
@@ -92,7 +92,7 @@ exports[`should render the component and match the snapshot 1`] = `
           >
             <a
               class="govuk-link"
-              href="/contact-us"
+              href="https://mojprod.service-now.com/"
             >
               Contact support
             </a>


### PR DESCRIPTION
This sets all of the "contact support" links throughout the service to point at https://mojprod.service-now.com/. 