### PR TITLE
Add back in 'email not received' help

### DIFF
--- a/cypress/integration/reset-password.spec.js
+++ b/cypress/integration/reset-password.spec.js
@@ -109,9 +109,9 @@ describe("Reset password", () => {
       cy.get("button[type=submit]").click()
       cy.get("body").contains(/sent you an email/i)
 
-      cy.get(".govuk-inset-text").should("not.exist")
-      cy.get("a[class=govuk-link]").click()
-      cy.get(".govuk-inset-text").should("not.be.empty")
+      cy.get("div[data-test='generated-password']").should("not.exist")
+      cy.get("a[data-test='generate-password']").click()
+      cy.get("div[data-test='generated-password']").should("not.be.empty")
     })
 
     it("should respond with forbidden response code when CSRF tokens are invalid in reset password page", (done) => {

--- a/src/components/SuggestPassword.tsx
+++ b/src/components/SuggestPassword.tsx
@@ -28,20 +28,26 @@ const SuggestPassword = ({ suggestedPassword, suggestedPasswordUrl }: Props) => 
       {!suggestedPassword && (
         <p className="govuk-body">
           {"If you need help choosing a password, we can "}
-          <Link href={suggestedPasswordUrl ?? ""}>{"suggest a password"}</Link>
+          <Link href={suggestedPasswordUrl ?? ""} data-test="generate-password">
+            {"suggest a password"}
+          </Link>
           {" for you."}
         </p>
       )}
       {suggestedPassword && (
         <>
           <p className="govuk-body">{"Here is a password suggestion:"}</p>
-          <div className="govuk-inset-text">{suggestedPassword}</div>
+          <div className="govuk-inset-text" data-test="generated-password">
+            {suggestedPassword}
+          </div>
           <p className="govuk-body">
             {"If you want to use this password, you can type it or copy and paste it into the fields above."}
           </p>
           <p className="govuk-body">
             {"If you don't want to use this password, we can "}
-            <Link href={suggestedPasswordUrl ?? ""}>{"suggest another password"}</Link>
+            <Link href={suggestedPasswordUrl ?? ""} data-test="generate-password">
+              {"suggest another password"}
+            </Link>
             {"."}
           </p>
         </>

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -32,6 +32,7 @@ import Database from "types/Database"
 import addQueryParams from "utils/addQueryParams"
 import UserFullDetails from "types/UserFullDetails"
 import { removeCjsmSuffix } from "lib/cjsmSuffix"
+import NotReceivedEmail from "components/NotReceivedEmail"
 
 const authenticationErrorMessage = "Error authenticating the reqest"
 
@@ -402,6 +403,7 @@ const Index = ({
             <p className="govuk-body">
               <p>{"If an account was found we will have sent you an email."}</p>
             </p>
+            <NotReceivedEmail sendAgainUrl="/login" />
             <input id="email" name="emailAddress" type="hidden" value={emailAddress} />
             <input type="hidden" name="loginStage" value="validateCode" />
             <TextInput

--- a/src/pages/login/reset-password.tsx
+++ b/src/pages/login/reset-password.tsx
@@ -28,6 +28,7 @@ import generateRandomPassword from "useCases/generateRandomPassword"
 import passwordSecurityCheck from "useCases/passwordSecurityCheck"
 import resetPassword, { ResetPasswordOptions } from "useCases/resetPassword"
 import SuccessBanner from "components/SuccessBanner"
+import NotReceivedEmail from "components/NotReceivedEmail"
 
 const handleEmailStage = async (
   context: GetServerSidePropsContext<ParsedUrlQuery>,
@@ -325,6 +326,7 @@ const ForgotPassword = ({
                 <p className="govuk-body">{"If an account was found we will have sent you an email."}</p>
                 <input id="email" name="emailAddress" type="hidden" value={emailAddress} />
                 <input type="hidden" name="resetStage" value="validateCode" />
+                <NotReceivedEmail sendAgainUrl="/login/reset-password" />
                 <TextInput
                   id="validationCode"
                   name="validationCode"


### PR DESCRIPTION
This PR adds the "I have not received the email" expandable help text to the new login page and password reset pages:

![image](https://user-images.githubusercontent.com/1678348/145569132-fc4a3e7a-e9fb-4aee-bfca-f2df1da7c984.png)
![image](https://user-images.githubusercontent.com/1678348/145569145-39ac9c66-443e-41ee-acb1-b8194231db22.png)
