### PR TITLE
Add banner in non-production environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The application makes use of the following environment variables to permit confi
 | `$EMAIL_FROM`                    | `"bichard@cjse.org"`               | The email address to send emails from                                                                |
 | `$EMAIL_VERIFICATION_EXPIRES_IN` | `30`                               | The number of minutes after which the email verification links will expire                           |
 | `$INCORRECT_DELAY`               | `10`                               | The amount of time (in seconds) to wait between successive login attemps for the same user           |
+| `$IS_PRODUCTION`                 | `false`                            | Whether the application is being run in production. Used to display a "development" warning banner.  |
 | `$REMEMBER_EMAIL_MAX_AGE`        | `1440`                             | The maximum validity of cookie for remembering user's email address in minutes                       |
 | `$SMTP_HOST`                     | `"console"`                        | The hostname of the SMTP server. If set to `console`, emails will be printed to the console instead. |
 | `$SMTP_USER`                     | `"bichard"`                        | The username to use when connecting to the SMTP server                                               |

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ The application makes use of the following environment variables to permit confi
 | `$DB_SSL`                        | `false`                            | Whether to use SSL when connecting to the database                                                   |
 | `$EMAIL_FROM`                    | `"bichard@cjse.org"`               | The email address to send emails from                                                                |
 | `$EMAIL_VERIFICATION_EXPIRES_IN` | `30`                               | The number of minutes after which the email verification links will expire                           |
+| `$HIDE_NON_PROD_BANNER`          | `false`                            | Whether the development environment warning banner should be shown                                   |
 | `$INCORRECT_DELAY`               | `10`                               | The amount of time (in seconds) to wait between successive login attemps for the same user           |
-| `$IS_PRODUCTION`                 | `false`                            | Whether the application is being run in production. Used to display a "development" warning banner.  |
 | `$REMEMBER_EMAIL_MAX_AGE`        | `1440`                             | The maximum validity of cookie for remembering user's email address in minutes                       |
 | `$SMTP_HOST`                     | `"console"`                        | The hostname of the SMTP server. If set to `console`, emails will be printed to the console instead. |
 | `$SMTP_USER`                     | `"bichard"`                        | The username to use when connecting to the SMTP server                                               |

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,9 @@ module.exports = {
   sassOptions: {
     quietDeps: true
   },
+  env: {
+    HIDE_NON_PROD_BANNER: process.env.HIDE_NON_PROD_BANNER
+  },
   async redirects() {
     return [
       {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 const Layout = ({ children, user }: Props) => (
   <>
-    {!config.isProduction && <NonProdBanner />}
+    {!config.hideNonProdBanner && <NonProdBanner />}
     <Header serviceName="Ministry of Justice" user={user} />
 
     <div className="govuk-width-container">

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,6 +2,8 @@ import { ReactNode } from "react"
 import Header from "components/Header"
 import Footer from "components/Footer"
 import User from "types/User"
+import config from "lib/config"
+import NonProdBanner from "./NonProdBanner"
 
 interface Props {
   children: ReactNode
@@ -10,10 +12,11 @@ interface Props {
 
 const Layout = ({ children, user }: Props) => (
   <>
+    {!config.isProduction && <NonProdBanner />}
     <Header serviceName="Ministry of Justice" user={user} />
 
-    <div className="govuk-width-container ">
-      <main className="govuk-main-wrapper " role="main">
+    <div className="govuk-width-container">
+      <main className="govuk-main-wrapper" role="main">
         {children}
       </main>
     </div>

--- a/src/components/NonProdBanner.tsx
+++ b/src/components/NonProdBanner.tsx
@@ -1,0 +1,22 @@
+import config from "lib/config"
+
+const whiteTextStyle = { color: "#fff" }
+const redBackgroundStyle = { backgroundColor: "#d4351c" }
+
+const NonProdBanner = () => (
+  <div className="govuk-phase-banner" style={redBackgroundStyle}>
+    <div className="govuk-width-container ">
+      <p className="govuk-phase-banner__content">
+        <strong className="govuk-tag govuk-tag--red govuk-phase-banner__content__tag">{"development"}</strong>
+        <span className="govuk-phase-banner__text" style={whiteTextStyle}>
+          {"This is a development version of Bichard that is being used for testing. "}
+          <a href={config.productionUrl} style={whiteTextStyle}>
+            {"Go to production instead."}
+          </a>
+        </span>
+      </p>
+    </div>
+  </div>
+)
+
+export default NonProdBanner

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -28,6 +28,7 @@ export interface UserServiceConfig {
   incorrectDelay: number
   isProduction: boolean
   passwordMinLength: number
+  productionUrl: string
   rememberEmailAddressCookieName: string
   rememberEmailAddressMaxAgeInMinutes: number
   suggestedPasswordNumWords: number
@@ -65,6 +66,7 @@ const config: UserServiceConfig = {
   incorrectDelay: parseInt(process.env.INCORRECT_DELAY ?? "10", 10),
   isProduction: process.env.IS_PRODUCTION === "true",
   passwordMinLength: 8,
+  productionUrl: "http://psnportal.bichard7.pnn.police.uk/",
   rememberEmailAddressCookieName: "LOGIN_EMAIL",
   rememberEmailAddressMaxAgeInMinutes: parseInt(process.env.REMEMBER_EMAIL_MAX_AGE ?? "1440", 10),
   suggestedPasswordNumWords: 3,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -26,6 +26,7 @@ export interface UserServiceConfig {
   emailFrom: string
   emailVerificationExpiresIn: number
   incorrectDelay: number
+  isProduction: boolean
   passwordMinLength: number
   rememberEmailAddressCookieName: string
   rememberEmailAddressMaxAgeInMinutes: number
@@ -62,6 +63,7 @@ const config: UserServiceConfig = {
   emailFrom: `Bichard7 <${process.env.EMAIL_FROM ?? "bichard@cjse.org"}>`,
   emailVerificationExpiresIn: parseInt(process.env.EMAIL_VERIFICATION_EXPIRY ?? "30", 10),
   incorrectDelay: parseInt(process.env.INCORRECT_DELAY ?? "10", 10),
+  isProduction: process.env.IS_PRODUCTION === "true",
   passwordMinLength: 8,
   rememberEmailAddressCookieName: "LOGIN_EMAIL",
   rememberEmailAddressMaxAgeInMinutes: parseInt(process.env.REMEMBER_EMAIL_MAX_AGE ?? "1440", 10),

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -25,8 +25,8 @@ export interface UserServiceConfig {
   debugMode: string
   emailFrom: string
   emailVerificationExpiresIn: number
+  hideNonProdBanner: boolean
   incorrectDelay: number
-  isProduction: boolean
   passwordMinLength: number
   productionUrl: string
   rememberEmailAddressCookieName: string
@@ -63,8 +63,8 @@ const config: UserServiceConfig = {
   debugMode: "false",
   emailFrom: `Bichard7 <${process.env.EMAIL_FROM ?? "bichard@cjse.org"}>`,
   emailVerificationExpiresIn: parseInt(process.env.EMAIL_VERIFICATION_EXPIRY ?? "30", 10),
+  hideNonProdBanner: process.env.HIDE_NON_PROD_BANNER === "true",
   incorrectDelay: parseInt(process.env.INCORRECT_DELAY ?? "10", 10),
-  isProduction: process.env.IS_PRODUCTION === "true",
   passwordMinLength: 8,
   productionUrl: "http://psnportal.bichard7.pnn.police.uk/",
   rememberEmailAddressCookieName: "LOGIN_EMAIL",

--- a/test/pages/__snapshots__/403.test.tsx.snap
+++ b/test/pages/__snapshots__/403.test.tsx.snap
@@ -2,6 +2,36 @@
 
 exports[`should render the component and match the snapshot 1`] = `
 <div>
+  <div
+    class="govuk-phase-banner"
+    style="background-color: rgb(212, 53, 28);"
+  >
+    <div
+      class="govuk-width-container "
+    >
+      <p
+        class="govuk-phase-banner__content"
+      >
+        <strong
+          class="govuk-tag govuk-tag--red govuk-phase-banner__content__tag"
+        >
+          development
+        </strong>
+        <span
+          class="govuk-phase-banner__text"
+          style="color: rgb(255, 255, 255);"
+        >
+          This is a development version of Bichard that is being used for testing. 
+          <a
+            href="http://psnportal.bichard7.pnn.police.uk/"
+            style="color: rgb(255, 255, 255);"
+          >
+            Go to production instead.
+          </a>
+        </span>
+      </p>
+    </div>
+  </div>
   <header
     class="govuk-header"
     data-module="govuk-header"
@@ -65,10 +95,10 @@ exports[`should render the component and match the snapshot 1`] = `
     </div>
   </header>
   <div
-    class="govuk-width-container "
+    class="govuk-width-container"
   >
     <main
-      class="govuk-main-wrapper "
+      class="govuk-main-wrapper"
       role="main"
     >
       <div

--- a/test/pages/__snapshots__/500.test.tsx.snap
+++ b/test/pages/__snapshots__/500.test.tsx.snap
@@ -2,6 +2,36 @@
 
 exports[`should render the component and match the snapshot 1`] = `
 <div>
+  <div
+    class="govuk-phase-banner"
+    style="background-color: rgb(212, 53, 28);"
+  >
+    <div
+      class="govuk-width-container "
+    >
+      <p
+        class="govuk-phase-banner__content"
+      >
+        <strong
+          class="govuk-tag govuk-tag--red govuk-phase-banner__content__tag"
+        >
+          development
+        </strong>
+        <span
+          class="govuk-phase-banner__text"
+          style="color: rgb(255, 255, 255);"
+        >
+          This is a development version of Bichard that is being used for testing. 
+          <a
+            href="http://psnportal.bichard7.pnn.police.uk/"
+            style="color: rgb(255, 255, 255);"
+          >
+            Go to production instead.
+          </a>
+        </span>
+      </p>
+    </div>
+  </div>
   <header
     class="govuk-header"
     data-module="govuk-header"
@@ -65,10 +95,10 @@ exports[`should render the component and match the snapshot 1`] = `
     </div>
   </header>
   <div
-    class="govuk-width-container "
+    class="govuk-width-container"
   >
     <main
-      class="govuk-main-wrapper "
+      class="govuk-main-wrapper"
       role="main"
     >
       <div


### PR DESCRIPTION
This PR adds a banner at the top of all user-service pages explaining that the application being viewed is not the production version of Bichard:

![image](https://user-images.githubusercontent.com/1678348/146543020-afcbd109-1f0e-4249-a0df-085e13657cb3.png)

The display of this banner is controlled by the `$HIDE_NON_PROD_BANNER` environment variable. The link at the end of the banner goes to the PNN hostname for the live Bichard instance, which is hard-coded in the config file.