### PR TITLE
Include "by" user in user create/edit/delete audit log messages

### DIFF
--- a/src/pages/users/[username]/delete.tsx
+++ b/src/pages/users/[username]/delete.tsx
@@ -73,7 +73,7 @@ export const getServerSideProps = withMultipleServerSideProps(
       let deleteUserResult
 
       if (currentUser.id && currentUser.id !== user.id) {
-        deleteUserResult = await deleteUser(connection, auditLogger, user, currentUser.id)
+        deleteUserResult = await deleteUser(connection, auditLogger, user, currentUser)
       } else {
         return {
           props: {

--- a/src/pages/users/[username]/edit.tsx
+++ b/src/pages/users/[username]/edit.tsx
@@ -115,7 +115,7 @@ export const getServerSideProps = withMultipleServerSideProps(
         }
 
         const auditLogger = getAuditLogger(context, config)
-        const userUpdated = await updateUser(connection, auditLogger, currentUser.id, userDetails)
+        const userUpdated = await updateUser(connection, auditLogger, currentUser, userDetails)
 
         if (isError(userUpdated)) {
           logger.error(userUpdated)

--- a/src/useCases/deleteUser.ts
+++ b/src/useCases/deleteUser.ts
@@ -13,15 +13,15 @@ export default async (
   db: Database,
   auditLogger: AuditLogger,
   user: Partial<User>,
-  currentUserId: number
+  currentUser: Partial<User>
 ): Promise<DeleteUserResult> => {
-  const markUserAsDeletedResult = await markUserAsDeleted(db, user.emailAddress as string, currentUserId)
+  const markUserAsDeletedResult = await markUserAsDeleted(db, user.emailAddress as string, currentUser.id as number)
 
   if (isError(markUserAsDeletedResult)) {
     return { serverSideError: markUserAsDeletedResult }
   }
 
-  await auditLogger("Delete user", { user })
+  await auditLogger("Delete user", { user, by: currentUser })
 
   return { isDeleted: true }
 }

--- a/src/useCases/setupNewUser.ts
+++ b/src/useCases/setupNewUser.ts
@@ -30,7 +30,7 @@ export default async (
     return result
   }
 
-  await auditLogger("Create user", { user: userCreateDetails })
+  await auditLogger("Create user", { user: userCreateDetails, by: currentUser })
 
   const createNewUserEmailResult = createNewUserEmail(userCreateDetails, baseUrl)
 

--- a/src/useCases/updateUser.ts
+++ b/src/useCases/updateUser.ts
@@ -36,9 +36,9 @@ const updateUsersGroup = (
       user_id,
       group_id
     )
-    SELECT 
+    SELECT
       $\{targetUserId\} AS user_id,
-      group_id 
+      group_id
     FROM br7own.users_groups AS ug
     WHERE
       ug.user_id = $\{currentUserId\} AND
@@ -75,7 +75,7 @@ const updateUserTable = async (task: ITask<unknown>, userDetails: Partial<User>)
 const updateUser = async (
   connection: Database,
   auditLogger: AuditLogger,
-  currentUserId: number,
+  currentUser: Partial<User>,
   userDetails: Partial<User>
 ): PromiseResult<void | Error> => {
   const result = await connection.tx(async (task: ITask<unknown>): PromiseResult<void> => {
@@ -83,6 +83,7 @@ const updateUser = async (
       ? userDetails.groups.map((group: UserGroupResult) => parseInt(group.id, 10))
       : []
     const userId = userDetails.id as number
+    const currentUserId = currentUser.id as number
     const updateUserResult = await updateUserTable(task, userDetails)
 
     if (isError(updateUserResult)) {
@@ -112,7 +113,7 @@ const updateUser = async (
     return new Error("There was an error while updating the user. Please try again.")
   }
 
-  await auditLogger("Edit user", { user: userDetails })
+  await auditLogger("Edit user", { user: userDetails, by: currentUser })
 
   return undefined
 }

--- a/test/useCases/updateUser.integration.test.ts
+++ b/test/useCases/updateUser.integration.test.ts
@@ -30,7 +30,7 @@ describe("updatePassword", () => {
   })
 
   const insertUserWithGroup = async () => {
-    const currentUserId = (await selectFromTable("users", "username", "Bichard01"))[0].id
+    const currentUser = (await selectFromTable("users", "username", "Bichard01"))[0]
     const selectedGroups = await selectFromTable("groups", undefined, undefined, "name")
     const initialGroup = selectedGroups[0]
 
@@ -49,7 +49,7 @@ describe("updatePassword", () => {
       excludedTriggers: "TRPR0001,"
     }
 
-    await createUser(connection, currentUserId, createUserDetails)
+    await createUser(connection, currentUser, createUserDetails)
   }
 
   it("should update user successfully when called", async () => {
@@ -59,7 +59,7 @@ describe("updatePassword", () => {
       "bichard01@example.com",
       groups.map((g) => g.name)
     )
-    const currentUserId = (await selectFromTable("users", "username", "Bichard01"))[0].id
+    const currentUser = (await selectFromTable("users", "username", "Bichard01"))[0]
 
     await insertUserWithGroup()
     const emailAddress = "bichard02@example.com"
@@ -82,7 +82,7 @@ describe("updatePassword", () => {
       excludedTriggers: "TRPR0002,"
     }
 
-    const result = await updateUser(connection, fakeAuditLogger, currentUserId, user)
+    const result = await updateUser(connection, fakeAuditLogger, currentUser, user)
     expect(result).toBeUndefined()
 
     const initialUser02 = (await selectFromTable("users", "email", emailAddress))[0]
@@ -107,7 +107,7 @@ describe("updatePassword", () => {
       groups.map((g) => g.name)
     )
     const updatedEmail = "bichard05@example.com"
-    const currentUserId = (await selectFromTable("users", "username", "Bichard01"))[0].id
+    const currentUser = (await selectFromTable("users", "username", "Bichard01"))[0]
 
     await insertUserWithGroup()
     const emailAddress = "bichard02@example.com"
@@ -131,7 +131,7 @@ describe("updatePassword", () => {
       excludedTriggers: "TRPR0002,"
     }
 
-    const result = await updateUser(connection, fakeAuditLogger, currentUserId, user)
+    const result = await updateUser(connection, fakeAuditLogger, currentUser, user)
     expect(result).toBeUndefined()
     const initialUserList02 = await selectFromTable("users", "email", updatedEmail)
     const initialUser02 = initialUserList02[0]
@@ -146,7 +146,7 @@ describe("updatePassword", () => {
       "bichard01@example.com",
       groups.map((g) => g.name)
     )
-    const currentUserId = (await selectFromTable("users", "username", "Bichard01"))[0].id
+    const currentUser = (await selectFromTable("users", "username", "Bichard01"))[0]
 
     await insertUserWithGroup()
     const expectedError = Error("Error updating user")
@@ -167,7 +167,7 @@ describe("updatePassword", () => {
       excludedTriggers: "TRPR0002,"
     }
 
-    const result = await updateUser(connection, fakeAuditLogger, currentUserId, user)
+    const result = await updateUser(connection, fakeAuditLogger, currentUser, user)
     expect(isError(expectedError)).toBe(true)
 
     const actualError = result as Error
@@ -181,7 +181,7 @@ describe("updatePassword", () => {
       "bichard01@example.com",
       groups.map((g) => g.name)
     )
-    const currentUserId = (await selectFromTable("users", "username", "Bichard01"))[0].id
+    const currentUser = (await selectFromTable("users", "username", "Bichard01"))[0]
 
     const selectedGroups = await selectFromTable("groups", undefined, undefined, "name")
     const initialGroup = selectedGroups[0]
@@ -202,7 +202,7 @@ describe("updatePassword", () => {
       excludedTriggers: user.excluded_triggers
     }
 
-    await createUser(connection, currentUserId, createUserDetails)
+    await createUser(connection, currentUser, createUserDetails)
 
     const initialUserList = await selectFromTable("users", "email", user.email)
     const initialUser = initialUserList[0]
@@ -223,7 +223,7 @@ describe("updatePassword", () => {
 
     updateUserDetails[initialGroup.name] = "yes"
 
-    const updateResult = await updateUser(connection, fakeAuditLogger, currentUserId, updateUserDetails)
+    const updateResult = await updateUser(connection, fakeAuditLogger, currentUser, updateUserDetails)
     expect(isError(updateResult)).toBe(false)
 
     const expectedUsers = await selectFromTable("users", "email", user.email)
@@ -242,7 +242,7 @@ describe("updatePassword", () => {
       "bichard01@example.com",
       groups.map((g) => g.name)
     )
-    const currentUserId = (await selectFromTable("users", "username", "Bichard01"))[0].id
+    const currentUser = (await selectFromTable("users", "username", "Bichard01"))[0]
 
     const selectedGroups = await selectFromTable("groups", undefined, undefined, "name")
     const initialGroup = selectedGroups[0]
@@ -267,7 +267,7 @@ describe("updatePassword", () => {
       excludedTriggers: user.excluded_triggers
     }
 
-    await createUser(connection, currentUserId, createUserDetails)
+    await createUser(connection, currentUser, createUserDetails)
 
     const initialUserList = await selectFromTable("users", "email", "bichard01@example.com")
     const initialUser = initialUserList[0]
@@ -286,7 +286,7 @@ describe("updatePassword", () => {
       excludedTriggers: "TRPR0002,"
     }
 
-    const updateResult = await updateUser(connection, fakeAuditLogger, currentUserId, updateUserDetails)
+    const updateResult = await updateUser(connection, fakeAuditLogger, currentUser, updateUserDetails)
     expect(isError(updateResult)).toBe(false)
 
     const expectedUsersGroups = await selectFromTable("users_groups", "user_id", initialUser.id)
@@ -300,7 +300,7 @@ describe("updatePassword", () => {
       "bichard01@example.com",
       groups.map((g) => g.name)
     )
-    const currentUserId = (await selectFromTable("users", "username", "Bichard01"))[0].id
+    const currentUser = (await selectFromTable("users", "username", "Bichard01"))[0]
 
     const selectedGroups = await selectFromTable("groups", undefined, undefined, "name")
     const initialGroup = selectedGroups[0]
@@ -321,7 +321,7 @@ describe("updatePassword", () => {
       excludedTriggers: user.excluded_triggers
     }
 
-    await createUser(connection, currentUserId, createUserDetails)
+    await createUser(connection, currentUser, createUserDetails)
 
     const initialUserList = await selectFromTable("users", "email", user.email)
     const initialUser = initialUserList[0]
@@ -340,7 +340,7 @@ describe("updatePassword", () => {
       excludedTriggers: "TRPR0002,"
     }
 
-    const updateResult = await updateUser(connection, fakeAuditLogger, currentUserId, updateUserDetails)
+    const updateResult = await updateUser(connection, fakeAuditLogger, currentUser, updateUserDetails)
     expect(isError(updateResult)).toBe(false)
 
     const expectedUser = (await selectFromTable("users", "email", user.email))[0]
@@ -378,7 +378,7 @@ describe("updatePassword", () => {
 
     updateUserDetails[groups[1].name] = "yes"
     // When the current user updates a user
-    const updateResult = await updateUser(connection, fakeAuditLogger, currentUser.id, updateUserDetails)
+    const updateResult = await updateUser(connection, fakeAuditLogger, currentUser, updateUserDetails)
 
     // Then the updated user is updates succesfully and only has the groups the current user can assign
     expect(isError(updateResult)).toBe(false)


### PR DESCRIPTION
This PR updates the audit log messages that are generated when creating/editing/deleting a user to include details on the user that is making those changes too.

TL;DR instead of saying "user 'Bichard02' was deleted", we're now saying "user 'Bichard02' was deleted by 'Bichard01'"