### PR TITLE
Make email address checking case-insensitive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,7 @@ jobs:
     machine:
       image: ubuntu-2004:202104-01
       docker_layer_caching: true
+    resource_class: large
     working_directory: ~
     parallelism: 4
     steps:

--- a/cypress/integration/login.spec.js
+++ b/cypress/integration/login.spec.js
@@ -80,6 +80,21 @@ describe("Logging In", () => {
       })
     })
 
+    it("should allow login with case-insensitive email address", () => {
+      cy.visit("/login")
+      cy.get("input[type=email]").type(user.email.toUpperCase())
+      cy.get("button[type=submit]").click()
+      cy.get("input#validationCode").should("exist")
+      cy.task("getVerificationCode", user.email).then((verificationCode) => {
+        cy.get("input#validationCode").type(verificationCode)
+        cy.get("input#password").type(user.password)
+        cy.get("button[type=submit]").click()
+        cy.url().should("match", /\/users/)
+        cy.get("body").should("contain", "Welcome Bichard User 01")
+        cy.getCookie(authCookieName).should("exist")
+      })
+    })
+
     it("should accept a correct password and verification code even after incorrect password attempt", () => {
       cy.visit("/login")
       cy.get("input[type=email]").type(user.email)

--- a/cypress/integration/reset-password.spec.js
+++ b/cypress/integration/reset-password.spec.js
@@ -20,6 +20,15 @@ describe("Reset password", () => {
       cy.get("body").contains(/sent you an email/i)
     })
 
+    it("should ignore email case when resetting the password", () => {
+      cy.visit("/login")
+      cy.get("a[data-test='reset-password']").click()
+      cy.get("body").contains(/reset password/i)
+      cy.get("input[type=email]").type(user.email.toUpperCase())
+      cy.get("button[type=submit]").click()
+      cy.get("body").contains(/sent you an email/i)
+    })
+
     it("should not allow submission when passwords are too short", () => {
       cy.visit(`/login/reset-password`)
       cy.get("input[name=emailAddress]").type(user.email)

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="next" />
+/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "bichard7-next-user-service",
       "version": "0.1.0",
       "dependencies": {
         "@trust/webcrypto": "^0.9.2",

--- a/src/useCases/authenticate.ts
+++ b/src/useCases/authenticate.ts
@@ -21,7 +21,7 @@ const fetchGroups = async (task: ITask<unknown>, emailAddress: string): Promise<
         ON g.id = ug.group_id
       INNER JOIN br7own.users u
         ON ug.user_id = u.id
-      WHERE u.email = $1 AND u.deleted_at IS NULL
+      WHERE LOWER(u.email) = LOWER($1) AND u.deleted_at IS NULL
     `
   let groups = await task.any(fetchGroupsQuery, [emailAddress])
   groups = groups.map((group: { name: string }) => group.name.replace(/_grp$/, ""))
@@ -48,7 +48,7 @@ const getUserWithInterval = async (task: ITask<unknown>, params: unknown[]): Pro
     migrated_password,
     deleted_at
   FROM br7own.users
-  WHERE email = $1`
+  WHERE LOWER(email) = LOWER($1)`
 
   const user = await task.one(getUserQuery, params)
 
@@ -84,7 +84,7 @@ const updateUserLoginTimestamp = async (task: ITask<unknown>, emailAddress: stri
   const updateUserQuery = `
       UPDATE br7own.users
       SET last_login_attempt = NOW()
-      WHERE email = $1
+      WHERE LOWER(email) = LOWER($1)
     `
 
   await task.none(updateUserQuery, [emailAddress])

--- a/src/useCases/checkPassword.ts
+++ b/src/useCases/checkPassword.ts
@@ -8,7 +8,7 @@ export default async (db: Database, emailAddress: string, password: string): Pro
   const query = `
     SELECT password
     FROM br7own.users
-    WHERE email = $1 AND deleted_at IS NULL
+    WHERE LOWER(email) = LOWER($1) AND deleted_at IS NULL
   `
   const queryResult = await db.one(query, [emailAddress]).catch((error) => error)
 

--- a/src/useCases/getEmailVerificationCode.ts
+++ b/src/useCases/getEmailVerificationCode.ts
@@ -7,7 +7,7 @@ export default async (connection: Database, emailAddress: string): PromiseResult
     SELECT
       email_verification_code AS "emailVerificationCode"
     FROM br7own.users
-    WHERE email = $1 AND deleted_at IS NULL
+    WHERE LOWER(email) = LOWER($1) AND deleted_at IS NULL
   `
   const result = await connection
     .oneOrNone<{ passwordResetCode: string }>(query, [emailAddress])

--- a/src/useCases/getFailedPasswordAttempts.ts
+++ b/src/useCases/getFailedPasswordAttempts.ts
@@ -7,7 +7,7 @@ export default async (connection: Database, emailAddress: string): PromiseResult
         SELECT
             failed_password_attempts AS "failedPasswordAttempts"
         FROM br7own.users
-        WHERE email = $1 AND deleted_at IS NULL
+        WHERE LOWER(email) = LOWER($1) AND deleted_at IS NULL
     `
 
   const result = await connection.oneOrNone(query, [emailAddress]).catch((error) => error)

--- a/src/useCases/getPasswordResetCode.ts
+++ b/src/useCases/getPasswordResetCode.ts
@@ -7,7 +7,7 @@ export default async (connection: Database, emailAddress: string): PromiseResult
     SELECT
       password_reset_code AS "passwordResetCode"
     FROM br7own.users
-    WHERE email = $1 AND deleted_at IS NULL
+    WHERE LOWER(email) = LOWER($1) AND deleted_at IS NULL
   `
   const result = await connection
     .oneOrNone<{ passwordResetCode: string }>(query, [emailAddress])

--- a/src/useCases/getUserByEmailAddress.ts
+++ b/src/useCases/getUserByEmailAddress.ts
@@ -16,7 +16,7 @@ export default (db: Database, emailAddress: string): PromiseResult<User | null> 
         visible_forces AS "visibleForces",
         excluded_triggers AS "excludedTriggers"
       FROM br7own.users
-      WHERE email = $1 AND deleted_at IS NULL
+      WHERE LOWER(email) = LOWER($1) AND deleted_at IS NULL
     `
   return db.oneOrNone<User>(query, [emailAddress]).catch((error) => error)
 }

--- a/src/useCases/getUserLoginDetailsByEmailAddress.ts
+++ b/src/useCases/getUserLoginDetailsByEmailAddress.ts
@@ -8,7 +8,7 @@ export default (db: Database, emailAddress: string): PromiseResult<Pick<UserFull
         id,
         password
       FROM br7own.users
-      WHERE email = \${emailAddress}
+      WHERE LOWER(email) = LOWER(\${emailAddress})
         AND deleted_at IS NULL
     `
   return db.one<Pick<UserFullDetails, "id" | "password">>(query, { emailAddress }).catch((error) => error)

--- a/src/useCases/markUserAsDeleted.ts
+++ b/src/useCases/markUserAsDeleted.ts
@@ -5,7 +5,7 @@ export default (db: Database, emailAddress: string, currentUserId: number): Prom
   const query = `
       UPDATE br7own.users
       SET deleted_at = NOW()
-      WHERE email = $1 AND Id != $2 AND deleted_at IS NULL
+      WHERE LOWER(email) = LOWER($1) AND id != $2 AND deleted_at IS NULL
     `
 
   return db.none(query, [emailAddress, currentUserId]).catch((error) => error)

--- a/src/useCases/resetUserVerificationCode.ts
+++ b/src/useCases/resetUserVerificationCode.ts
@@ -6,7 +6,7 @@ const resetUserVerificationCode = async (connection: Database, emailAddress: str
         UPDATE br7own.users
         SET email_verification_code = NULL,
           failed_password_attempts = 0
-        WHERE email = $1
+        WHERE LOWER(email) = LOWER($1)
           AND deleted_at IS NULL
       `
 

--- a/src/useCases/setFailedPasswordAttempts.ts
+++ b/src/useCases/setFailedPasswordAttempts.ts
@@ -5,7 +5,7 @@ export default (connection: Database, emailAddress: string, failedPasswordAttemp
   const query = `
         UPDATE br7own.users
         SET failed_password_attempts = $\{failedPasswordAttempts\}
-        WHERE email = $\{emailAddress\} AND deleted_at IS NULL
+        WHERE LOWER(email) = LOWER($\{emailAddress\}) AND deleted_at IS NULL
     `
 
   return connection.none(query, { failedPasswordAttempts, emailAddress }).catch((error) => error)

--- a/src/useCases/storePasswordResetCode.ts
+++ b/src/useCases/storePasswordResetCode.ts
@@ -10,13 +10,13 @@ export default async (
   let updateUserQuery = `
     UPDATE br7own.users
     SET password_reset_code = $1
-    WHERE email = $2 AND deleted_at IS NULL
+    WHERE LOWER(email) = LOWER($2) AND deleted_at IS NULL
   `
   if (passwordResetCode === null) {
     updateUserQuery = `
       UPDATE br7own.users
       SET password_reset_code = NULL
-      WHERE email = $2 AND deleted_at IS NULL
+      WHERE LOEWR(email) = LOWER($2) AND deleted_at IS NULL
     `
   }
   const result = await connection.result(updateUserQuery, [passwordResetCode, emailAddress]).catch((error) => error)

--- a/src/useCases/storeVerificationCode.ts
+++ b/src/useCases/storeVerificationCode.ts
@@ -8,7 +8,7 @@ export default async (connection: Database, emailAddress: string, verificationCo
     SET email_verification_code = $1,
       email_verification_generated = NOW(),
       failed_password_attempts = 0
-    WHERE email = $2 AND deleted_at IS NULL
+    WHERE LOWER(email) = LOWER($2) AND deleted_at IS NULL
   `
   const result = await connection
     .result(storeVerificationQuery, [verificationCode, emailAddress])

--- a/src/useCases/updatePassword.ts
+++ b/src/useCases/updatePassword.ts
@@ -11,7 +11,7 @@ export default async (connection: Database | Task, emailAddress: string, newPass
     UPDATE br7own.users
     SET email_verification_code = NULL,
     password = \${passwordHash}
-    WHERE email = \${emailAddress}
+    WHERE LOWER(email) = LOWER(\${emailAddress})
       AND deleted_at IS NULL
   `
   const result = await connection

--- a/src/useCases/validateUserVerificationCode.ts
+++ b/src/useCases/validateUserVerificationCode.ts
@@ -14,7 +14,7 @@ const validateUserVerificationCode = async (
   const query = `
     SELECT *
     FROM br7own.users
-    WHERE email = $1
+    WHERE LOWER(email) = LOWER($1)
       AND password_reset_code = $2
       AND deleted_at IS NULL
     `

--- a/test/useCases/authenticateUser.integration.test.ts
+++ b/test/useCases/authenticateUser.integration.test.ts
@@ -109,7 +109,7 @@ describe("Authenticator", () => {
       `
       UPDATE br7own.users
       SET last_login_attempt = NOW() - INTERVAL '$\{interval\} seconds'
-      WHERE email = $\{email\}`,
+      WHERE LOWER(email) = LOWER($\{email\})`,
       { interval: config.incorrectDelay, email: emailAddress }
     )
 
@@ -148,7 +148,7 @@ describe("Authenticator", () => {
       `
       UPDATE br7own.users
       SET last_login_attempt = NOW() - INTERVAL '$\{interval\} seconds'
-      WHERE email = $\{email\}`,
+      WHERE LOWER(email) = LOWER($\{email\})`,
       { interval: config.incorrectDelay, email: emailAddress }
     )
 
@@ -183,7 +183,7 @@ describe("Authenticator", () => {
       `
       UPDATE br7own.users
       SET last_login_attempt = NOW() - INTERVAL '$\{interval\} seconds'
-      WHERE email = $\{email\}`,
+      WHERE LOWER(email) = LOWER($\{email\})`,
       { interval: config.incorrectDelay, email: emailAddress }
     )
 
@@ -200,7 +200,7 @@ describe("Authenticator", () => {
       `
       UPDATE br7own.users
       SET last_login_attempt = NOW() - INTERVAL '$\{interval\} seconds'
-      WHERE email = $\{email\}`,
+      WHERE LOWER(email) = LOWER($\{email\})`,
       { interval: config.incorrectDelay, email: emailAddress }
     )
 
@@ -217,7 +217,7 @@ describe("Authenticator", () => {
       `
       UPDATE br7own.users
       SET last_login_attempt = NOW() - INTERVAL '$\{interval\} seconds'
-      WHERE email = $\{email\}`,
+      WHERE LOWER(email) = LOWER($\{email\})`,
       { interval: config.incorrectDelay, email: emailAddress }
     )
 

--- a/test/useCases/resetPassword.integration.test.ts
+++ b/test/useCases/resetPassword.integration.test.ts
@@ -53,7 +53,7 @@ describe("resetPassword", () => {
     expect(result).toBeUndefined()
 
     const actualUser = await connection.oneOrNone(
-      `SELECT username, password FROM br7own.users WHERE email = $\{email\}`,
+      `SELECT username, password FROM br7own.users WHERE LOWER(email) = LOWER($\{email\})`,
       {
         email: emailAddress
       }


### PR DESCRIPTION
This PR:

- Makes all database queries that check email address use `LOWER()` on both sides of the check:
    ```diff
    - WHERE email = $1
    + WHERE LOWER(email) = LOWER($1)
    ```
    - This means that when you want to login or reset your password you can type your email address using any combination of upper/lowercase characters and it will still work
- Adds a couple of cypress tests to try logging in and resetting passwords using an uppercase email address 