### PR TITLE
Clarify why users not in any group cannot log in to bichard

### DIFF
--- a/cypress/integration/faq.spec.js
+++ b/cypress/integration/faq.spec.js
@@ -15,10 +15,10 @@ describe("FAQ", () => {
     cy.get("[data-test='faq_last-updated']").should("contain", "04-01-2022")
   })
 
-  it("should display the expected 5 questions and answers", () => {
+  it("should display the expected 6 questions and answers", () => {
     // When
     cy.visit("/faq")
     // Then
-    cy.get("[data-test='faq-item']").should("have.length", "5")
+    cy.get("[data-test='faq-item']").should("have.length", "6")
   })
 })

--- a/src/faqs.json
+++ b/src/faqs.json
@@ -25,6 +25,11 @@
       "id": "inactivity-log-out",
       "question": "Why am I getting logged out of Bichard?",
       "answer": "Bichard will automatically log you out after 10 minutes of inactivity. You will need to verify your email again unless you click the “Remember me” checkbox on the login page, in which case you will only need to use your password for the next 24 hours."
+    },
+    {
+      "id": "no-bichard-button",
+      "question": "Why can I not see the 'Access Bichard' button?",
+      "answer": "You do not have any Bichard groups associated with your account. If this is incorrect, please contact a User Manager in your force."
     }
   ]
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -121,6 +121,14 @@ const Home = ({
               </Link>
             )}
 
+            {!hasAccessToBichard && (
+              <Paragraph>
+                {
+                  "You do not have any Bichard groups associated with your account. If this is incorrect, please contact a User Manager in your force."
+                }
+              </Paragraph>
+            )}
+
             {(hasAccessToUserManagement || hasAccessToAuditLogging) && (
               <>
                 <h3 className="govuk-heading-m govuk-!-margin-top-5" id="services-title">

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -491,6 +491,11 @@ const Index = ({
               {"I have forgotten my password"}
             </Link>
           </Paragraph>
+          <Paragraph>
+            {"If you need help with anything else, you can "}
+            <ContactLink>{"contact support"}</ContactLink>
+            {"."}
+          </Paragraph>
         </GridColumn>
         <GridColumn width="one-third">
           <ServiceMessages messages={serviceMessages} />


### PR DESCRIPTION
This PR:

## Adds explainer text to the index page for logged in users who cannot access bichard (BICAWS-1694)

Users without access to bichard see this screen:

> ![Screenshot 2022-01-26 at 10 49 48](https://user-images.githubusercontent.com/7249529/151152119-edaddaea-32d1-4c12-b812-466f74f85a79.png)

as opposed to the usual "Access Bichard" button:

> ![Screenshot 2022-01-26 at 10 28 59](https://user-images.githubusercontent.com/7249529/151152253-6f17337e-1a6e-48fb-a7d3-bffa43bd6c9d.png)


## Adds a FAQ item explaining why users not in any group cannot log in to bichard (BICAWS-1694)

> ![Screenshot 2022-01-26 at 11 01 34](https://user-images.githubusercontent.com/7249529/151151929-807b154e-405a-4169-959b-42d2dbbb074b.png)

## Adds a link to the FAQ to the login page

> ![Screenshot 2022-01-26 at 11 08 19](https://user-images.githubusercontent.com/7249529/151152752-8363119e-ed47-4ec4-84a3-e461f1bef4fd.png)
