### PR TITLE
Only create npm dependency PRs once per week, rather than every day

### DIFF
--- a/.github/workflows/update-npm-deps.yml
+++ b/.github/workflows/update-npm-deps.yml
@@ -2,7 +2,7 @@ name: Update npm dependencies
 
 on:
   schedule:
-    - cron: '0 8 * * 1-5'
+    - cron: '0 8 * * 1'
 
 jobs:
   update_deps:


### PR DESCRIPTION
Instead of running the GitHub Action every weekday at 8am, this PR makes it run only on Mondays at 8am.

We need to be careful that these auto-generated PRs don't become a burden and start getting ignored by the team. Merging a PR once each week is better than ignoring a PR that gets updated every day.