### PR TITLE
Load a fake image on every page load if user doesn't have JS enabled

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,6 @@
-import { ReactNode } from "react"
-import Header from "components/Header"
 import Footer from "components/Footer"
+import Header from "components/Header"
+import { ReactNode } from "react"
 import User from "types/User"
 
 interface Props {
@@ -8,12 +8,21 @@ interface Props {
   user?: Partial<User>
 }
 
+/* eslint-disable jsx-a11y/alt-text, @next/next/no-img-element */
+const FakeAssetForNoJsStatsGathering = () => (
+  <noscript>
+    <img src="/assets/nojs.png" className="govuk-!-display-none" />
+  </noscript>
+)
+/* eslint-enable jsx-a11y/alt-text, @next/next/no-img-element */
+
 const Layout = ({ children, user }: Props) => (
   <>
+    <FakeAssetForNoJsStatsGathering />
     <Header serviceName="Ministry of Justice" user={user} />
 
-    <div className="govuk-width-container ">
-      <main className="govuk-main-wrapper " role="main">
+    <div className="govuk-width-container">
+      <main className="govuk-main-wrapper" role="main">
         {children}
       </main>
     </div>


### PR DESCRIPTION
This PR adds an image with a dummy `src` inside a `<noscript>` tag in the main Layout component of the user-service. This means that if the user doesn't have Javascript enabled and is visiting any of the pages in the user-service (e.g. the login page or the home page), then their browser will make a request to the dummy image.

The idea is that after a while of this being deployed, we'll be able to check the NGINX logs and determine how many requests are made (which is a rough approximation on the number of users) without Javascript enabled.

The image itself has a govuk class applied to it that will prevent it from actually showing up.