### PR TITLE
Add a dummy script link to log user force ids

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -192,6 +192,7 @@ const Home = ({
           </GridColumn>
         </GridRow>
       </Layout>
+      <script src={`forces.js?forceID=${currentUser?.visibleForces}`} async />
     </>
   )
 }


### PR DESCRIPTION
Add a script link to the Home page HTML markup to log the users' force IDs. This link doesn't exist and will be logged in Cloudwatch by Nginx. We can then later see these logs in OpenSearch to check if forces can access Bichard.