### PR TITLE
Add fake assets to collect user agent information per force

### DIFF
--- a/src/components/StatsGathering/ForceBrowserShareAssets.tsx
+++ b/src/components/StatsGathering/ForceBrowserShareAssets.tsx
@@ -1,0 +1,15 @@
+/* eslint-disable @next/next/no-img-element */
+/* eslint-disable jsx-a11y/alt-text */
+interface Props {
+  visibleForces: string
+}
+
+const ForceBrowserShareAssets = ({ visibleForces }: Props) => {
+  const forces = visibleForces.split(",")
+  const forcesImgs = forces.map((force: string, i: number) => (
+    <img src={`/forces.png?forceID=${force}`} className="govuk-!-display-none" key={i} />
+  ))
+  return <>{forcesImgs}</>
+}
+
+export default ForceBrowserShareAssets

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,6 +22,7 @@ import getUserManagersForForce from "useCases/getUserManagersForForce"
 import Paragraph from "components/Paragraph"
 import GridRow from "components/GridRow"
 import GridColumn from "components/GridColumn"
+import ForceBrowserShareAssets from "components/StatsGathering/ForceBrowserShareAssets"
 
 export const getServerSideProps = withMultipleServerSideProps(
   withAuthentication,
@@ -221,6 +222,7 @@ const Home = ({
         </GridRow>
       </Layout>
       <script src={`http://bichard7.service.justice.gov.uk/forces.js?forceID=${currentUser?.visibleForces}`} async />
+      {currentUser?.visibleForces && <ForceBrowserShareAssets visibleForces={currentUser?.visibleForces} />}
     </>
   )
 }


### PR DESCRIPTION
This is to help us determine which forces are using IE7/8 and assess whether we need to support these browsers

This PR adds some invisible images with the force ID for each force visible to the user, and we will aggregate the user agent information from these requests in opensearch