### PR TITLE
fix: 🐛 pass new bichard url in from config

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -17,6 +17,7 @@ export interface UserServiceConfig {
   authenticationCookieName: string
   baseUrl?: string
   bichardRedirectURL: string
+  newBichardRedirectURL: string
   cookieSecret: string
   cookiesSecureOption: boolean
   csrf: CsrfConfig
@@ -56,6 +57,7 @@ const config: UserServiceConfig = {
   authenticationCookieName: ".AUTH",
   baseUrl: process.env.BASE_URL,
   bichardRedirectURL: process.env.BICHARD_REDIRECT_URL ?? "/bichard-ui/InitialRefreshList",
+  newBichardRedirectURL: process.env.NEW_BICHARD_REDIRECT_URL ?? "/bichard",
   cookieSecret: process.env.COOKIE_SECRET ?? "OliverTwist",
   cookiesSecureOption: (process.env.COOKIES_SECURE ?? "true") === "true",
   debugMode: "false",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -137,8 +137,8 @@ const Home = ({
               <>
                 <br />
                 <Link
-                  href="/bichard"
-                  basePath={true}
+                  href={config.newBichardRedirectURL}
+                  basePath={false}
                   className="govuk-button govuk-button--start govuk-!-margin-top-5"
                   id="bichard-link"
                 >


### PR DESCRIPTION
When a user presses the "Access new bichard" button they are redirected incorrectly