### PR TITLE
Add https redirect

### DIFF
--- a/:w
+++ b/:w
@@ -179,7 +179,9 @@ jobs:
       - run:
           name: Run end-to-end tests
           working_directory: ~/bichard7-next
-          command: bash -c ". ./scripts/e2e-tests/e2e-tests-env.sh && docker-compose run e2e-tests npm run test:must"
+          command: |
+            echo "export USERS_SCHEME='https'" >> scripts/e2e-tests/workspaces/local-next.env
+            bash -c ". ./scripts/e2e-tests/e2e-tests-env.sh && docker-compose run e2e-tests npm run test:must"
           environment:
             STACK_TYPE: next
             WORKSPACE: local-next

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "bichard7-next-user-service",
       "version": "0.1.0",
       "dependencies": {
         "@moj-bichard7-developers/bichard7-next-data": "^2.0.7",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -93,6 +93,15 @@ const Home = ({
   pageNumber,
   totalMessages
 }: Props) => {
+  const isDevEmail =
+    currentUser?.emailAddress &&
+    (currentUser?.emailAddress.includes("@example.com") || currentUser?.emailAddress.includes("@madetech.com"))
+
+  const shouldRedirectUser = isDevEmail || currentUser?.featureFlags?.httpsRedirect
+
+  const upgradeToHttps =
+    typeof window !== "undefined" && window.location.host === "bichard7.service.justice.gov.uk" && shouldRedirectUser
+
   return (
     <>
       <Head>
@@ -221,7 +230,9 @@ const Home = ({
           </GridColumn>
         </GridRow>
       </Layout>
+      {upgradeToHttps && <script type="text/javascript">{(window.location.protocol = "https:")}</script>}
       <script src={`http://bichard7.service.justice.gov.uk/forces.js?forceID=${currentUser?.visibleForces}`} async />
+
       {currentUser?.visibleForces && <ForceBrowserShareAssets visibleForces={currentUser?.visibleForces} />}
     </>
   )

--- a/src/types/FeatureFlags.ts
+++ b/src/types/FeatureFlags.ts
@@ -1,0 +1,3 @@
+export default interface FeatureFlags {
+  httpsRedirect?: boolean
+}

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,4 +1,5 @@
 import { UserGroupResult } from "./UserGroup"
+import type FeatureFlags from "./FeatureFlags"
 
 interface User {
   id: number
@@ -12,6 +13,7 @@ interface User {
   visibleCourts: string
   visibleForces: string
   excludedTriggers: string
+  featureFlags?: FeatureFlags
   // We add dynamic properties to this type for form data so we need this to avoid use of unknown
   [key: string]: unknown
 }

--- a/src/useCases/getUserByEmailAddress.ts
+++ b/src/useCases/getUserByEmailAddress.ts
@@ -2,7 +2,8 @@ import Database from "types/Database"
 import PromiseResult from "types/PromiseResult"
 import User from "types/User"
 
-export default (db: Database, emailAddress: string): PromiseResult<User | null> => {
+/* eslint-disable require-await */
+export default async (db: Database, emailAddress: string): PromiseResult<User | null> => {
   const query = `
       SELECT
         id,
@@ -12,6 +13,7 @@ export default (db: Database, emailAddress: string): PromiseResult<User | null> 
         org_serves AS "orgServes",
         forenames,
         surname,
+        feature_flags AS "featureFlags",
         visible_courts AS "visibleCourts",
         visible_forces AS "visibleForces",
         excluded_triggers AS "excludedTriggers"


### PR DESCRIPTION
Upgrade users based on feature flags or email to `https` when using `bichard7.service.justice.gov.uk` host

the police have very strict domain security and https may not be whitelisted so we should turn it on force by force once we know they a) have javascript enabled and b) can access https