### PR TITLE
fix: 🐛 only affects devs atm, feature flags havent been enabled

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -100,7 +100,10 @@ const Home = ({
   const shouldRedirectUser = isDevEmail || currentUser?.featureFlags?.httpsRedirect
 
   const upgradeToHttps =
-    typeof window !== "undefined" && window.location.host === "bichard7.service.justice.gov.uk" && shouldRedirectUser
+    typeof window !== "undefined" &&
+    window.location.host === "bichard7.service.justice.gov.uk" &&
+    !window.location.protocol.includes("https") &&
+    shouldRedirectUser
 
   return (
     <>


### PR DESCRIPTION
User gets stuck in a reload loop as the js script attempts to continuously set their protocol, this guards against the loop.