### PR TITLE
fix: 🐛 revert https redirect script

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -93,18 +93,6 @@ const Home = ({
   pageNumber,
   totalMessages
 }: Props) => {
-  const isDevEmail =
-    currentUser?.emailAddress &&
-    (currentUser?.emailAddress.includes("@example.com") || currentUser?.emailAddress.includes("@madetech.com"))
-
-  const shouldRedirectUser = isDevEmail || currentUser?.featureFlags?.httpsRedirect
-
-  const upgradeToHttps =
-    typeof window !== "undefined" &&
-    window.location.host === "bichard7.service.justice.gov.uk" &&
-    !window.location.protocol.includes("https") &&
-    shouldRedirectUser
-
   return (
     <>
       <Head>
@@ -233,7 +221,6 @@ const Home = ({
           </GridColumn>
         </GridRow>
       </Layout>
-      {upgradeToHttps && <script type="text/javascript">{(window.location.protocol = "https:")}</script>}
       <script src={`http://bichard7.service.justice.gov.uk/forces.js?forceID=${currentUser?.visibleForces}`} async />
 
       {currentUser?.visibleForces && <ForceBrowserShareAssets visibleForces={currentUser?.visibleForces} />}


### PR DESCRIPTION
The redirect doesn't redirect immediately because the different protocol is consider a different site which means cookies (`samesite: "strict"`) are blocked and the user is logged out (unless they refresh manually from the browser)