### PR TITLE
Make npm cache files under /tmp rather than /root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ FROM ${BUILD_IMAGE} as runner
 
 RUN useradd nextjs && \
     groupadd nodejs && \
-    usermod -a -G nodejs nextjs
+    usermod -a -G nodejs nextjs && \
+    npm config set cache /tmp/npm --global
 
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production


### PR DESCRIPTION
This was causing startup issues with the user-service process inside the docker container. In short, what we think was happening was:

 - supervisorctl was starting npm as the nextjs user
 - npm was starting a node process as the nextjs
 - npm was then failing to write to `/root/.npm/...` and exiting with a weird status code, despite having already started the node process
 - supervisorctl detected that npm exited and tried to restart it again
 - npm was then failing to start the node process as the port (3000) was already in use by the previous node process
 - supervisorctl was then giving up on starting the user service and saying that it was in a failed state
 - supervisorctl was therefore unable to process/forward any logs for the user service process

Making npm use `/tmp` rather than `/root` as its cache directory means that it is actually able to write files, and so doesn't complain, and starts up properly.

See also https://github.com/ministryofjustice/bichard7-next-ui/pull/129.