### PR TITLE
Add GitHub actions alert to update npm dependencies 

### DIFF
--- a/.github/workflows/update-npm-deps.yml
+++ b/.github/workflows/update-npm-deps.yml
@@ -20,7 +20,6 @@ jobs:
 
       - name: Install dependencies
         run: npm install
-             exit 1
 
       - name: Update dependencies
         run: npm run update-deps

--- a/.github/workflows/update-npm-deps.yml
+++ b/.github/workflows/update-npm-deps.yml
@@ -1,6 +1,7 @@
 name: Update npm dependencies
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 8 * * 1'
 

--- a/.github/workflows/update-npm-deps.yml
+++ b/.github/workflows/update-npm-deps.yml
@@ -19,6 +19,7 @@ jobs:
 
       - name: Install dependencies
         run: npm install
+             exit 1
 
       - name: Update dependencies
         run: npm run update-deps

--- a/.github/workflows/update-npm-deps.yml
+++ b/.github/workflows/update-npm-deps.yml
@@ -1,7 +1,6 @@
 name: Update npm dependencies
 
 on:
-  workflow_dispatch:
   schedule:
     - cron: '0 8 * * 1'
 

--- a/.github/workflows/update-npm-deps.yml
+++ b/.github/workflows/update-npm-deps.yml
@@ -19,9 +19,22 @@ jobs:
 
       - name: Install dependencies
         run: npm install
+             exit 1
 
       - name: Update dependencies
         run: npm run update-deps
+
+      - name: Report Status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ job.status }}
+          notification_title: 'GitHub action failed'
+          message_format: ':elmo-fire: *{workflow}* {status_message} in <{repo_url}|{repo}>'
+          notify_when: 'failure'
+          footer: 'Linked to Repo <{repo_url}|{repo}>'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
       - name: Create pull request
         id: cpr


### PR DESCRIPTION
This PR is to notify when the update `npm dependacies` script fails. It alerts the `moj-cjse-bichard-alerts` channel