### PR TITLE
Added newUI checks to hasAccessToUrl checks with tests

### DIFF
--- a/src/types/UserGroup.ts
+++ b/src/types/UserGroup.ts
@@ -8,6 +8,7 @@ type UserGroup =
   | "B7UserManager"
   | "B7AuditLoggingManager"
   | "B7SuperUserManager"
+  | "B7NewUI"
 
 export type UserGroupResult = {
   id: string

--- a/src/useCases/getUserServiceAccess.ts
+++ b/src/useCases/getUserServiceAccess.ts
@@ -14,8 +14,7 @@ const bichardGroups = [
   "B7ExceptionHandler",
   "B7GeneralHandler",
   "B7Supervisor",
-  "B7TriggerHandler",
-  "B7NewUI"
+  "B7TriggerHandler"
 ]
 
 export default ({ groups }: AuthenticationTokenPayload): GetUserServiceAccessResult => {

--- a/src/useCases/hasUserAccessToUrl.ts
+++ b/src/useCases/hasUserAccessToUrl.ts
@@ -3,7 +3,7 @@ import getUserServiceAccess from "./getUserServiceAccess"
 
 const userManagementUrlExpression = /^\/users\/users.*/
 const bichardUrlExpression = /^\/bichard-ui.*/
-const newBichardUrlExpression = /^\/bichard\/.*|^\/bichard$/
+const newBichardUrlExpression = /^\/bichard\/.*|^\/bichard$\/?/
 const reportsUrlExpression = /^\/reports\/.*/
 
 export default (token: AuthenticationTokenPayload, url?: string): boolean => {

--- a/src/useCases/hasUserAccessToUrl.ts
+++ b/src/useCases/hasUserAccessToUrl.ts
@@ -3,6 +3,7 @@ import getUserServiceAccess from "./getUserServiceAccess"
 
 const userManagementUrlExpression = /^\/users\/users.*/
 const bichardUrlExpression = /^\/bichard-ui.*/
+const newBichardUrlExpression = /^\/bichard\/.*|^\/bichard$/
 const reportsUrlExpression = /^\/reports\/.*/
 
 export default (token: AuthenticationTokenPayload, url?: string): boolean => {
@@ -10,12 +11,14 @@ export default (token: AuthenticationTokenPayload, url?: string): boolean => {
     return false
   }
 
-  const { hasAccessToBichard, hasAccessToUserManagement, hasAccessToReports } = getUserServiceAccess(token)
+  const { hasAccessToBichard, hasAccessToUserManagement, hasAccessToReports, hasAccessToNewBichard } =
+    getUserServiceAccess(token)
 
   if (
     (url.match(userManagementUrlExpression) && !hasAccessToUserManagement) ||
     (url.match(bichardUrlExpression) && !hasAccessToBichard) ||
-    (url.match(reportsUrlExpression) && !hasAccessToReports)
+    (url.match(reportsUrlExpression) && !hasAccessToReports) ||
+    (url.match(newBichardUrlExpression) && !hasAccessToNewBichard)
   ) {
     return false
   }

--- a/test/useCases/hasUserAccessToUrl.test.ts
+++ b/test/useCases/hasUserAccessToUrl.test.ts
@@ -53,6 +53,36 @@ const testData: TestData[] = [
     group: null,
     url: "/users/logout",
     expectedResult: true
+  },
+  {
+    group: null,
+    url: "/bichard",
+    expectedResult: false
+  },
+  {
+    group: null,
+    url: "/bichard/",
+    expectedResult: false
+  },
+  {
+    group: "B7ExceptionHandler",
+    url: "/bichard",
+    expectedResult: false
+  },
+  {
+    group: "B7NewUI",
+    url: "/bichard",
+    expectedResult: true
+  },
+  {
+    group: "B7NewUI",
+    url: "/bichard/",
+    expectedResult: true
+  },
+  {
+    group: "B7NewUI",
+    url: "/bichard/court-cases/0",
+    expectedResult: true
   }
 ]
 

--- a/test/useCases/hasUserAccessToUrl.test.ts
+++ b/test/useCases/hasUserAccessToUrl.test.ts
@@ -83,6 +83,11 @@ const testData: TestData[] = [
     group: "B7NewUI",
     url: "/bichard/court-cases/0",
     expectedResult: true
+  },
+  {
+    group: "B7NewUI",
+    url: "/bichard-ui/",
+    expectedResult: false
   }
 ]
 


### PR DESCRIPTION
This ticket is to prevent users from visiting the new-UI using the path directly. 

Extended existing `hasAccessToUrl` function to include newUI groups. 
Added ontop of existing unit tests. 
