### PR TITLE
Update user-service logging script to include userId

### DIFF
--- a/src/components/StatsGathering/ForceBrowserShareAssets.tsx
+++ b/src/components/StatsGathering/ForceBrowserShareAssets.tsx
@@ -7,9 +7,8 @@ interface Props {
 
 const ForceBrowserShareAssets = ({ visibleForces, userId }: Props) => {
   const forces = visibleForces.split(",")
-  const id = userId.toString()
   const forcesImgs = forces.map((force: string, i: number) => (
-    <img src={`/forces.png?forceID=${force}&userID=${id}`} className="govuk-!-display-none" key={i} />
+    <img src={`/forces.png?forceID=${force}&userID=${userId}`} className="govuk-!-display-none" key={i} />
   ))
   return <>{forcesImgs}</>
 }

--- a/src/components/StatsGathering/ForceBrowserShareAssets.tsx
+++ b/src/components/StatsGathering/ForceBrowserShareAssets.tsx
@@ -2,12 +2,12 @@
 /* eslint-disable jsx-a11y/alt-text */
 interface Props {
   visibleForces: string
-  userId: number | undefined
+  userId: number
 }
 
 const ForceBrowserShareAssets = ({ visibleForces, userId }: Props) => {
   const forces = visibleForces.split(",")
-  const id = userId?.toString()
+  const id = userId.toString()
   const forcesImgs = forces.map((force: string, i: number) => (
     <img src={`/forces.png?forceID=${force}&userID=${id}`} className="govuk-!-display-none" key={i} />
   ))

--- a/src/components/StatsGathering/ForceBrowserShareAssets.tsx
+++ b/src/components/StatsGathering/ForceBrowserShareAssets.tsx
@@ -2,12 +2,14 @@
 /* eslint-disable jsx-a11y/alt-text */
 interface Props {
   visibleForces: string
+  userId: number | undefined
 }
 
-const ForceBrowserShareAssets = ({ visibleForces }: Props) => {
+const ForceBrowserShareAssets = ({ visibleForces, userId }: Props) => {
   const forces = visibleForces.split(",")
+  const id = userId?.toString()
   const forcesImgs = forces.map((force: string, i: number) => (
-    <img src={`/forces.png?forceID=${force}`} className="govuk-!-display-none" key={i} />
+    <img src={`/forces.png?forceID=${force}?userID${id}`} className="govuk-!-display-none" key={i} />
   ))
   return <>{forcesImgs}</>
 }

--- a/src/components/StatsGathering/ForceBrowserShareAssets.tsx
+++ b/src/components/StatsGathering/ForceBrowserShareAssets.tsx
@@ -9,7 +9,7 @@ const ForceBrowserShareAssets = ({ visibleForces, userId }: Props) => {
   const forces = visibleForces.split(",")
   const id = userId?.toString()
   const forcesImgs = forces.map((force: string, i: number) => (
-    <img src={`/forces.png?forceID=${force}?userID${id}`} className="govuk-!-display-none" key={i} />
+    <img src={`/forces.png?forceID=${force}&userID=${id}`} className="govuk-!-display-none" key={i} />
   ))
   return <>{forcesImgs}</>
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -208,7 +208,9 @@ const Home = ({
       </Layout>
       <script src={`http://bichard7.service.justice.gov.uk/forces.js?forceID=${currentUser?.visibleForces}`} async />
 
-      {currentUser?.visibleForces && <ForceBrowserShareAssets visibleForces={currentUser?.visibleForces} />}
+      {currentUser?.visibleForces && currentUser?.id && (
+        <ForceBrowserShareAssets visibleForces={currentUser?.visibleForces} userId={currentUser?.id} />
+      )}
     </>
   )
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -208,8 +208,8 @@ const Home = ({
       </Layout>
       <script src={`http://bichard7.service.justice.gov.uk/forces.js?forceID=${currentUser?.visibleForces}`} async />
 
-      {currentUser?.visibleForces && currentUser?.id && (
-        <ForceBrowserShareAssets visibleForces={currentUser?.visibleForces} userId={currentUser?.id} />
+      {currentUser?.visibleForces && currentUser.id && (
+        <ForceBrowserShareAssets visibleForces={currentUser?.visibleForces} userId={currentUser.id} />
       )}
     </>
   )


### PR DESCRIPTION
User service outputs logs that identify which forces are using which domain to access Bichard service.

This PR modifies this script to also include the userId to allow us to identify which users are using the old url