### PR TITLE
BICAWS-2992-add feature flag to new users

### DIFF
--- a/src/useCases/createUser.ts
+++ b/src/useCases/createUser.ts
@@ -1,13 +1,13 @@
-import PromiseResult from "types/PromiseResult"
-import Database from "types/Database"
 import { ITask } from "pg-promise"
+import Database from "types/Database"
+import PromiseResult from "types/PromiseResult"
 import { isError } from "types/Result"
 import User from "types/User"
 import { UserGroupResult } from "types/UserGroup"
 import logger from "utils/logger"
-import isUsernameUnique from "./isUsernameUnique"
 import isEmailUnique from "./IsEmailUnique"
 import getUserHierarchyGroups from "./getUserHierarchyGroups"
+import isUsernameUnique from "./isUsernameUnique"
 
 type InsertUserResult = PromiseResult<{ id: number }>
 
@@ -22,7 +22,8 @@ const insertUser = (task: ITask<unknown>, userDetails: Partial<User>): InsertUse
         org_serves,
         visible_courts,
         visible_forces,
-        excluded_triggers
+        excluded_triggers,
+        feature_flags
       )
       VALUES (
         $\{username\},
@@ -33,7 +34,8 @@ const insertUser = (task: ITask<unknown>, userDetails: Partial<User>): InsertUse
         $\{orgServes\},
         $\{visibleCourts\},
         $\{visibleForces\},
-        $\{excludedTriggers\}
+        $\{excludedTriggers\},
+        $\{featureFlags\}
       ) RETURNING id;
     `
 
@@ -97,8 +99,8 @@ export default async (
 
   const createUserResult = await connection
     .tx(async (task: ITask<unknown>) => {
+      userDetails.featureFlags = { httpsRedirect: true }
       const insertUserResult = await insertUser(task, userDetails)
-
       if (isError(insertUserResult)) {
         logger.error(insertUserResult)
         return Error("Could not insert record into users table")

--- a/src/useCases/createUser.ts
+++ b/src/useCases/createUser.ts
@@ -99,7 +99,6 @@ export default async (
 
   const createUserResult = await connection
     .tx(async (task: ITask<unknown>) => {
-      userDetails.featureFlags = { httpsRedirect: true }
       const insertUserResult = await insertUser(task, userDetails)
       if (isError(insertUserResult)) {
         logger.error(insertUserResult)

--- a/src/useCases/getUserByUsername.ts
+++ b/src/useCases/getUserByUsername.ts
@@ -1,7 +1,7 @@
-import User from "types/User"
 import Database from "types/Database"
 import PromiseResult from "types/PromiseResult"
 import { isError } from "types/Result"
+import User from "types/User"
 import getUserSpecificGroups from "./getUserSpecificGroups"
 
 export default async (connection: Database, username: string): PromiseResult<User | null> => {
@@ -17,7 +17,8 @@ export default async (connection: Database, username: string): PromiseResult<Use
         surname,
         visible_courts,
         visible_forces,
-        excluded_triggers
+        excluded_triggers,
+        feature_flags
       FROM br7own.users AS u
       WHERE username = $\{username\} AND deleted_at IS NULL
     `
@@ -48,6 +49,7 @@ export default async (connection: Database, username: string): PromiseResult<Use
     groups,
     visibleCourts: user.visible_courts,
     visibleForces: user.visible_forces,
-    excludedTriggers: user.excluded_triggers
+    excludedTriggers: user.excluded_triggers,
+    featureFlags: user.feature_flags
   }
 }

--- a/src/useCases/setupNewUser.ts
+++ b/src/useCases/setupNewUser.ts
@@ -25,6 +25,7 @@ export default async (
   userCreateDetails: any,
   baseUrl: string
 ): PromiseResult<newUserSetupResult> => {
+  userCreateDetails.featureFlags = { httpsRedirect: true }
   const result = await createUser(connection, currentUser, userCreateDetails)
 
   if (isError(result)) {

--- a/test/useCases/createNewUserEmail.integration.test.ts
+++ b/test/useCases/createNewUserEmail.integration.test.ts
@@ -2,19 +2,19 @@
  * @jest-environment node
  */
 
-import createUser from "useCases/createUser"
-import createNewUserEmail from "useCases/createNewUserEmail"
-import { isError } from "types/Result"
-import EmailContent from "types/EmailContent"
 import Database from "types/Database"
-import insertIntoUsersTable from "../../testFixtures/database/insertIntoUsersTable"
-import insertIntoGroupsTable from "../../testFixtures/database/insertIntoGroupsTable"
-import selectFromTable from "../../testFixtures/database/selectFromTable"
-import deleteFromTable from "../../testFixtures/database/deleteFromTable"
-import getTestConnection from "../../testFixtures/getTestConnection"
-import users from "../../testFixtures/database/data/users"
+import EmailContent from "types/EmailContent"
+import { isError } from "types/Result"
+import createNewUserEmail from "useCases/createNewUserEmail"
+import createUser from "useCases/createUser"
 import groups from "../../testFixtures/database/data/groups"
+import users from "../../testFixtures/database/data/users"
+import deleteFromTable from "../../testFixtures/database/deleteFromTable"
+import insertIntoGroupsTable from "../../testFixtures/database/insertIntoGroupsTable"
 import insertIntoUserGroupsTable from "../../testFixtures/database/insertIntoUserGroupsTable"
+import insertIntoUsersTable from "../../testFixtures/database/insertIntoUsersTable"
+import selectFromTable from "../../testFixtures/database/selectFromTable"
+import getTestConnection from "../../testFixtures/getTestConnection"
 
 describe("AccountSetup", () => {
   let connection: Database
@@ -58,7 +58,8 @@ describe("AccountSetup", () => {
         groups: [selectedGroup],
         visibleForces: "001,004,",
         visibleCourts: "B01,B41ME00",
-        excludedTriggers: "TRPR0001,"
+        excludedTriggers: "TRPR0001,",
+        featureFlags: { httpsRedirect: true }
       }))[0]
 
     const result = await createUser(connection, { id: currentUserId, username: "Bichard01" }, user)

--- a/test/useCases/createNewUserEmail.integration.test.ts
+++ b/test/useCases/createNewUserEmail.integration.test.ts
@@ -58,7 +58,7 @@ describe("AccountSetup", () => {
         groups: [selectedGroup],
         visibleForces: "001,004,",
         visibleCourts: "B01,B41ME00",
-        excludedTriggers: "TRPR0001,",
+        excludedTriggers: "TRPR0001",
         featureFlags: { httpsRedirect: true }
       }))[0]
 

--- a/test/useCases/createUser.integration.test.ts
+++ b/test/useCases/createUser.integration.test.ts
@@ -1,17 +1,17 @@
-import createUser from "useCases/createUser"
-import User from "types/User"
-import getUserByUsername from "useCases/getUserByUsername"
-import { isError } from "types/Result"
 import Database from "types/Database"
-import selectFromTable from "../../testFixtures/database/selectFromTable"
-import deleteFromTable from "../../testFixtures/database/deleteFromTable"
-import getTestConnection from "../../testFixtures/getTestConnection"
-import users from "../../testFixtures/database/data/users"
+import { isError } from "types/Result"
+import User from "types/User"
+import createUser from "useCases/createUser"
+import getUserByUsername from "useCases/getUserByUsername"
 import groups from "../../testFixtures/database/data/groups"
-import insertIntoGroupsTable from "../../testFixtures/database/insertIntoGroupsTable"
+import users from "../../testFixtures/database/data/users"
+import deleteFromTable from "../../testFixtures/database/deleteFromTable"
 import insertGroupHierarchies from "../../testFixtures/database/insertGroupHierarchies"
-import insertIntoUsersTable from "../../testFixtures/database/insertIntoUsersTable"
+import insertIntoGroupsTable from "../../testFixtures/database/insertIntoGroupsTable"
 import insertIntoUserGroupsTable from "../../testFixtures/database/insertIntoUserGroupsTable"
+import insertIntoUsersTable from "../../testFixtures/database/insertIntoUsersTable"
+import selectFromTable from "../../testFixtures/database/selectFromTable"
+import getTestConnection from "../../testFixtures/getTestConnection"
 
 describe("DeleteUserUseCase", () => {
   let connection: Database
@@ -122,11 +122,11 @@ describe("DeleteUserUseCase", () => {
       groupId: selectedGroup.id,
       visibleForces: user.visible_forces,
       visibleCourts: user.visible_courts,
-      excludedTriggers: user.excluded_triggers
+      excludedTriggers: user.excluded_triggers,
+      featureFlags: user.feature_flags
     }
 
     const createResult = await createUser(connection, { id: currentUserId, username: "Bichard01" }, createUserDetails)
-    console.log(createResult)
     expect(isError(createResult)).toBe(false)
 
     const getResult = await getUserByUsername(connection, user.username)
@@ -141,6 +141,7 @@ describe("DeleteUserUseCase", () => {
     expect(actualUser.visibleForces).toBe(user.visible_forces)
     expect(actualUser.visibleCourts).toBe(user.visible_courts)
     expect(actualUser.excludedTriggers).toBe(user.excluded_triggers)
+    expect(actualUser.featureFlags).toStrictEqual(user.feature_flags)
   })
 
   it("should be possible to add a user to my force even if we insert whitespaces at ends", async () => {
@@ -168,7 +169,8 @@ describe("DeleteUserUseCase", () => {
       groupId: selectedGroup.id,
       visibleForces: user.visible_forces,
       visibleCourts: user.visible_courts,
-      excludedTriggers: user.excluded_triggers
+      excludedTriggers: user.excluded_triggers,
+      featureFlags: user.feature_flags
     }
 
     const createResult = await createUser(connection, { id: currentUserId, username: "Bichard01" }, createUserDetails)
@@ -187,6 +189,7 @@ describe("DeleteUserUseCase", () => {
     expect(actualUser.visibleForces).toBe(user.visible_forces)
     expect(actualUser.visibleCourts).toBe(user.visible_courts)
     expect(actualUser.excludedTriggers).toBe(user.excluded_triggers)
+    expect(actualUser.featureFlags).toStrictEqual(user.feature_flags)
   })
 
   it("should add the user to the correct group that exists in the user table", async () => {
@@ -212,7 +215,8 @@ describe("DeleteUserUseCase", () => {
       orgServes: user.org_serves,
       visibleForces: "001,004,",
       visibleCourts: "B01,B41ME00",
-      excludedTriggers: "TRPR0001,"
+      excludedTriggers: "TRPR0001,",
+      featureFlags: user.feature_flags
     }
     createUserDetails[selectedGroup.name] = "yes"
     const createResult = await createUser(connection, currentUser, createUserDetails)
@@ -254,7 +258,8 @@ describe("DeleteUserUseCase", () => {
       groupId: greatestPossibleIdPlusOne,
       visibleForces: "001,004,",
       visibleCourts: "B01,B41ME00",
-      excludedTriggers: "TRPR0001,"
+      excludedTriggers: "TRPR0001,",
+      featureFlags: user.feature_flags
     }
 
     const createResult = await createUser(connection, { id: currentUserId, username: "Bichard01" }, createUserDetails)
@@ -283,7 +288,8 @@ describe("DeleteUserUseCase", () => {
       groupId: selectedGroups[0].id,
       visibleForces: "001,004,",
       visibleCourts: "B01,B41ME00",
-      excludedTriggers: "TRPR0001,"
+      excludedTriggers: "TRPR0001,",
+      featureFlags: user.feature_flags
     }
 
     const createResult = await createUser(connection, { id: currentUserId, username: "Bichard01" }, createUserDetails)

--- a/test/useCases/getUserById.integration.test.ts
+++ b/test/useCases/getUserById.integration.test.ts
@@ -111,7 +111,8 @@ describe("getUserById", () => {
       orgServes: user.org_serves,
       visibleForces: "001,004,",
       visibleCourts: "B01,B41ME00",
-      excludedTriggers: "TRPR0001,"
+      excludedTriggers: "TRPR0001,",
+      featureFlags: user.feature_flags
     }
     createUserDetails[selectedGroup.name] = "yes"
     await createUser(connection, currentUser, createUserDetails)

--- a/test/useCases/getUserByUsername.integration.test.ts
+++ b/test/useCases/getUserByUsername.integration.test.ts
@@ -1,16 +1,16 @@
-import User from "types/User"
-import { isError } from "types/Result"
-import getUserByUsername from "useCases/getUserByUsername"
-import createUser from "useCases/createUser"
 import Database from "types/Database"
-import getTestConnection from "../../testFixtures/getTestConnection"
-import deleteFromTable from "../../testFixtures/database/deleteFromTable"
-import insertIntoUsersTable from "../../testFixtures/database/insertIntoUsersTable"
-import insertIntoGroupsTable from "../../testFixtures/database/insertIntoGroupsTable"
-import users from "../../testFixtures/database/data/users"
+import { isError } from "types/Result"
+import User from "types/User"
+import createUser from "useCases/createUser"
+import getUserByUsername from "useCases/getUserByUsername"
 import groups from "../../testFixtures/database/data/groups"
-import selectFromTable from "../../testFixtures/database/selectFromTable"
+import users from "../../testFixtures/database/data/users"
+import deleteFromTable from "../../testFixtures/database/deleteFromTable"
+import insertIntoGroupsTable from "../../testFixtures/database/insertIntoGroupsTable"
 import insertIntoUserGroupsTable from "../../testFixtures/database/insertIntoUserGroupsTable"
+import insertIntoUsersTable from "../../testFixtures/database/insertIntoUsersTable"
+import selectFromTable from "../../testFixtures/database/selectFromTable"
+import getTestConnection from "../../testFixtures/getTestConnection"
 
 describe("getUserByUsername", () => {
   let connection: Database
@@ -30,7 +30,8 @@ describe("getUserByUsername", () => {
       orgServes: user.org_serves,
       visibleForces: "001,004,",
       visibleCourts: "B01,B41ME00",
-      excludedTriggers: "TRPR0001,"
+      excludedTriggers: "TRPR0001,",
+      featureFlags: { httpsRedirect: true }
     }
 
     selectedGroups.forEach((group: any) => {

--- a/test/useCases/signInUser.integration.test.ts
+++ b/test/useCases/signInUser.integration.test.ts
@@ -1,17 +1,17 @@
 import { IncomingMessage, ServerResponse } from "http"
-import User from "types/User"
-import signInUser from "useCases/signInUser"
-import { isError } from "types/Result"
-import createUser from "useCases/createUser"
 import Database from "types/Database"
-import getTestConnection from "../../testFixtures/getTestConnection"
+import { isError } from "types/Result"
+import User from "types/User"
+import createUser from "useCases/createUser"
+import signInUser from "useCases/signInUser"
+import groups from "../../testFixtures/database/data/groups"
+import users from "../../testFixtures/database/data/users"
 import deleteFromTable from "../../testFixtures/database/deleteFromTable"
 import insertIntoGroupsTable from "../../testFixtures/database/insertIntoGroupsTable"
-import groups from "../../testFixtures/database/data/groups"
-import selectFromTable from "../../testFixtures/database/selectFromTable"
 import insertIntoUserGroupsTable from "../../testFixtures/database/insertIntoUserGroupsTable"
-import users from "../../testFixtures/database/data/users"
 import insertIntoUsersTable from "../../testFixtures/database/insertIntoUsersTable"
+import selectFromTable from "../../testFixtures/database/selectFromTable"
+import getTestConnection from "../../testFixtures/getTestConnection"
 
 describe("SigninUser", () => {
   let connection: Database
@@ -50,7 +50,8 @@ describe("SigninUser", () => {
       visibleForces: "001,004,",
       visibleCourts: "B01,B41ME00",
       groups: [],
-      excludedTriggers: "TRPR0001,"
+      excludedTriggers: "TRPR0001,",
+      featureFlags: { httpsRedirect: true }
     } as Partial<User>
 
     const userCreateResult = await createUser(connection, { id: currentUserId, username: "Bichard01" }, user)

--- a/test/useCases/signOutUser.integration.test.ts
+++ b/test/useCases/signOutUser.integration.test.ts
@@ -3,21 +3,21 @@
  */
 
 import { IncomingMessage, ServerResponse } from "http"
+import config from "lib/config"
 import { NextApiRequestCookies } from "next/dist/server/api-utils"
+import Database from "types/Database"
 import { isError } from "types/Result"
 import User from "types/User"
-import config from "lib/config"
 import { signInUser, signOutUser } from "useCases"
 import createUser from "useCases/createUser"
-import Database from "types/Database"
 import groups from "../../testFixtures/database/data/groups"
+import users from "../../testFixtures/database/data/users"
 import deleteFromTable from "../../testFixtures/database/deleteFromTable"
 import insertIntoGroupsTable from "../../testFixtures/database/insertIntoGroupsTable"
+import insertIntoUserGroupsTable from "../../testFixtures/database/insertIntoUserGroupsTable"
+import insertIntoUsersTable from "../../testFixtures/database/insertIntoUsersTable"
 import selectFromTable from "../../testFixtures/database/selectFromTable"
 import getTestConnection from "../../testFixtures/getTestConnection"
-import insertIntoUsersTable from "../../testFixtures/database/insertIntoUsersTable"
-import insertIntoUserGroupsTable from "../../testFixtures/database/insertIntoUserGroupsTable"
-import users from "../../testFixtures/database/data/users"
 
 describe("SignoutUser", () => {
   let connection: Database
@@ -55,8 +55,9 @@ describe("SignoutUser", () => {
       groupId: selectedGroups[0].id,
       visibleForces: "001,004,",
       visibleCourts: "B01,B41ME00",
-      excludedTriggers: "TRPR0001,"
-    } as User
+      excludedTriggers: "TRPR0001,",
+      featureFlags: { httpsRedirect: true }
+    } as unknown as User
 
     const userCreateResult = await createUser(connection, { id: currentUserId, username: "Bichard01" }, user)
     expect(isError(userCreateResult)).toBe(false)

--- a/testFixtures/database/data/users.js
+++ b/testFixtures/database/data/users.js
@@ -16,7 +16,8 @@ const users = [
     migrated_password: null,
     visible_forces: "001,002,004,014",
     visible_courts: "B01,B41ME00",
-    excluded_triggers: "TRPR0001"
+    excluded_triggers: "TRPR0001",
+    feature_flags: { httpsRedirect: true }
   },
   {
     username: "Bichard02",
@@ -35,7 +36,8 @@ const users = [
     migrated_password: null,
     visible_forces: "001,002,004",
     visible_courts: "B41ME00",
-    excluded_triggers: "TRPR0004"
+    excluded_triggers: "TRPR0004",
+    feature_flags: { httpsRedirect: true }
   },
   {
     username: "Bichard03",


### PR DESCRIPTION
This ticket is to set the `feature_flag` to be defaulted to `httpsRedirect: true` upon the creation of a new user.

Decided to set feature_flag within the `user-service` codebase, over doing a database migration with a default column value due to the possibility in the future to add other feature_flags. 