### PR TITLE
Update reference to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE="nginx-nodejs-supervisord"
+ARG BUILD_IMAGE="nginx-nodejs-2023-supervisord"
 
 # Build user-service app
 

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -4,7 +4,7 @@ set -e
 
 NOCACHE=${NOCACHE:-"false"}
 
-readonly DOCKER_REFERENCE="nginx-nodejs-supervisord"
+readonly DOCKER_REFERENCE="nginx-nodejs-2023-supervisord"
 
 function has_local_image() {
   IMAGES=$(docker images --filter=reference="${DOCKER_REFERENCE}:*" -q | wc -l)


### PR DESCRIPTION
This PR is to point the `Dockerfile` and `build-docker.sh` to use the new `nginx-nodejs-2023-supervisord` image