### PR TITLE
Update goss test

### DIFF
--- a/goss.yaml
+++ b/goss.yaml
@@ -110,8 +110,6 @@ user:
 process:
   nginx:
     running: true
-  node:
-    running: true
   supervisord:
     running: true
 http:

--- a/goss.yaml
+++ b/goss.yaml
@@ -114,7 +114,5 @@ process:
     running: true
 http:
   https://localhost/users/login:
-    request-headers:
-      - "X-Origin: http://localhost:3000"
     status: 200
     allow-insecure: true


### PR DESCRIPTION
In this PR:
- **Removed check for node process in goss test**: New version of Nextjs doesn't use node process to run the application
- **Removed redundant request-headers from goss test**: request-headers is not needed to check if user service url is working. It also causes issue when running goss test locally.