### PR TITLE
Bicaws 3050 store and show incident date

### DIFF
--- a/src/components/ServiceMessages.tsx
+++ b/src/components/ServiceMessages.tsx
@@ -19,9 +19,9 @@ const ServiceMessages = ({ messages }: Props) => (
             <time
               className="govuk-!-font-weight-bold govuk-!-font-size-14"
               aria-label="time"
-              title={format(new Date(message.createdAt), "dd MMMM yyyy HH:mm")}
+              title={format(new Date(message.incidentDate || message.createdAt), "dd MMMM yyyy HH:mm")}
             >
-              {format(new Date(message.createdAt), "dd MMMM yyyy")}
+              {format(new Date(message.incidentDate || message.createdAt), "dd MMMM yyyy")}
             </time>
             <br />
             {message.message}

--- a/src/types/ServiceMessage.ts
+++ b/src/types/ServiceMessage.ts
@@ -2,6 +2,7 @@ interface ServiceMessage {
   id: number
   message: string
   createdAt: Date
+  incidentDate?: Date
 }
 
 export default ServiceMessage

--- a/src/useCases/getServiceMessages.ts
+++ b/src/useCases/getServiceMessages.ts
@@ -11,11 +11,16 @@ export default async (connection: Database, page: number): PromiseResult<Paginat
     id, 
     message, 
     created_at AS "createdAt",
+    incident_date AS "incidentDate",
     COUNT(*) OVER() AS "allMessages"
   FROM 
     br7own.service_messages
   WHERE
-	  created_at >= NOW() - INTERVAL '${config.serviceMessagesStaleDays} days'
+    (incident_date IS NOT NULL AND incident_date BETWEEN DATE(NOW()) AND DATE(NOW()) + INTERVAL '${
+      config.serviceMessagesStaleDays + 1
+    } days')
+    OR
+    (incident_date IS NULL AND created_at >= DATE(NOW()) - INTERVAL '${config.serviceMessagesStaleDays} days')
   ORDER BY created_at DESC
     OFFSET ${page * config.maxServiceMessagesPerPage} ROWS
     FETCH NEXT ${config.maxServiceMessagesPerPage} ROWS ONLY

--- a/test/components/ServiceMessages.test.tsx
+++ b/test/components/ServiceMessages.test.tsx
@@ -6,7 +6,12 @@ it("should render the component and match the snapshot when there are messages",
   const messages: ServiceMessage[] = [
     { id: 1, message: "Message 1", createdAt: new Date("2021-09-28T10:12:13") },
     { id: 2, message: "Message 2", createdAt: new Date("2021-09-29T11:14:17") },
-    { id: 3, message: "Message 3", createdAt: new Date("2021-09-30T17:45:23") }
+    {
+      id: 3,
+      message: "Message 3",
+      createdAt: new Date("2021-09-30T17:45:23"),
+      incidentDate: new Date("2021-10-10T16:30:00")
+    }
   ]
   const { container } = render(<ServiceMessages messages={messages} />)
 

--- a/test/components/__snapshots__/ServiceMessages.test.tsx.snap
+++ b/test/components/__snapshots__/ServiceMessages.test.tsx.snap
@@ -56,9 +56,9 @@ exports[`should render the component and match the snapshot when there are messa
         <time
           aria-label="time"
           class="govuk-!-font-weight-bold govuk-!-font-size-14"
-          title="30 September 2021 17:45"
+          title="10 October 2021 16:30"
         >
-          30 September 2021
+          10 October 2021
         </time>
         <br />
         Message 3

--- a/testFixtures/database/data/serviceMessages.js
+++ b/testFixtures/database/data/serviceMessages.js
@@ -7,55 +7,68 @@ function getDate(daysInPast) {
 const serviceMessages = [
   {
     message: "Message 1",
-    created_at: getDate(270)
+    created_at: getDate(270),
+    incident_date: null
   },
   {
     message: "Message 2",
-    created_at: getDate(180)
+    created_at: getDate(180),
+    incident_date: null
   },
   {
     message: "Message 3",
-    created_at: getDate(90)
+    created_at: getDate(90),
+    incident_date: null
   },
   {
     message: "Message 4",
-    created_at: getDate(60)
+    created_at: getDate(60),
+    incident_date: null
   },
   {
     message: "Message 5",
-    created_at: getDate(35)
+    created_at: getDate(35),
+    incident_date: null
   },
   {
     message: "Message 6",
-    created_at: getDate(31)
+    created_at: getDate(31),
+    incident_date: null
   },
   {
     message: "Message 7",
-    created_at: getDate(27)
+    created_at: getDate(27),
+    incident_date: null
   },
   {
     message: "Message 8",
-    created_at: getDate(25)
+    created_at: getDate(25),
+    incident_date: null
   },
   {
     message: "Message 9",
-    created_at: getDate(20)
+    created_at: getDate(20),
+    incident_date: null
   },
   {
     message: "Message 10",
-    created_at: getDate(15)
+    created_at: getDate(15),
+    incident_date: null
   },
   {
     message: "Message 11",
-    created_at: getDate(10)
+    created_at: getDate(10),
+    incident_date: null
   },
   {
     message: "Message 12",
-    created_at: getDate(5)
+    created_at: getDate(5),
+    incident_date: null
   },
   {
     message: "Message 13",
-    created_at: new Date()
+    created_at: new Date(),
+    incident_date: null
   }
 ]
 

--- a/testFixtures/database/insertIntoServiceMessagesTable.js
+++ b/testFixtures/database/insertIntoServiceMessagesTable.js
@@ -7,10 +7,12 @@ const insertIntoServiceMessagesTable = (data) => {
     INSERT INTO
       br7own.service_messages(
         message,
-        created_at
+        created_at,
+        incident_date
       ) VALUES (
         $\{message\},
-        $\{created_at\}
+        $\{created_at\},
+        $\{incident_date\}
       )
   `
 


### PR DESCRIPTION
This PR updates service messages functionality so:
- Service messages are displayed for 30 days prior to the incident date
- Service messages are displayed on the incident date
- Service messages are not shown after the incident date
- If incident date not set, service message are not shown after 30 days have elapsed from creation date.