### PR TITLE
Bicaws7-2616: Add health check endpoint

### DIFF
--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -1,0 +1,15 @@
+import config from "../../lib/config"
+import type { NextApiRequest, NextApiResponse } from "next"
+
+export default function handler(_: NextApiRequest, res: NextApiResponse) {
+  const { NODE_ENV } = process.env
+
+  if (
+    NODE_ENV === "production" &&
+    (config.csrf.cookieSecret === "OliverTwist1" || config.csrf.formSecret === "OliverTwist2")
+  ) {
+    res.status(500).end()
+  } else {
+    res.status(200).end()
+  }
+}


### PR DESCRIPTION
Sending a request to `/users/api/health` will return a `500` if the `NODE_ENV` is `production`, and the CSRF token is not set. Will return a `200` otherwise.