### PR TITLE
Remove unhelpful user info log output

### DIFF
--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -273,8 +273,6 @@ const handleGet = (
     const notYourEmailAddressUrl = getNotYourEmailLink(query)
 
     if (emailAddress) {
-      logger.info(emailAddress)
-
       return {
         props: {
           csrfToken,


### PR DESCRIPTION
There's a lot of fairly unhelpful logs in the user-service CloudWatch which look a bit like this:
```JSON
{
    "level": 303030,
    "pid": 111111,
    "hostname": "hostname",
    "name": "user-service",
    "message": "user@email.com"
}
```

This PR should prevent the user service from generating any more of them.