### PR TITLE
Improve the user experience for error page and change the support links

### DIFF
--- a/cypress/e2e/403Page.cy.js
+++ b/cypress/e2e/403Page.cy.js
@@ -8,7 +8,7 @@ describe("403 - Access denied", () => {
     cy.contains("If you believe you have permission to access this page, you can contact support to report this issue.")
   })
 
-  it("should respond with the correct HTTP status code (404)", () => {
+  it("should respond with the correct HTTP status code (403)", () => {
     cy.request({
       failOnStatusCode: false,
       url: "/403"

--- a/cypress/e2e/faq.cy.js
+++ b/cypress/e2e/faq.cy.js
@@ -5,14 +5,6 @@ describe("FAQ", () => {
     cy.get("[data-test='faq_heading']").should("have.text", "Frequently Asked Questions")
   })
 
-  it("should display the correct last updated information", () => {
-    cy.visit("/faq")
-
-    cy.get("[data-test='faq_last-updated'").should("exist")
-    cy.get("[data-test='faq_last-updated'").should("contain", "Last Updated:")
-    cy.get("[data-test='faq_last-updated']").should("contain", "04-01-2022")
-  })
-
   it("should display the expected 6 questions and answers", () => {
     cy.visit("/faq")
 

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -10,9 +10,20 @@ interface Props {
   id?: string
   rel?: string
   title?: string
+  onClick?: (e: React.MouseEvent<HTMLElement>) => void
 }
 
-const Link = ({ children, basePath = true, className, "data-test": dataTest, href, id, rel, title }: Props) => (
+const Link = ({
+  children,
+  basePath = true,
+  className,
+  "data-test": dataTest,
+  href,
+  id,
+  rel,
+  title,
+  onClick
+}: Props) => (
   <a
     data-test={dataTest}
     href={basePath ? addBasePath(href) : href}
@@ -20,6 +31,7 @@ const Link = ({ children, basePath = true, className, "data-test": dataTest, hre
     id={id}
     rel={rel}
     title={title}
+    onClick={onClick}
   >
     {children}
   </a>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -31,7 +31,8 @@ export interface UserServiceConfig {
   rememberEmailAddressCookieName: string
   rememberEmailAddressMaxAgeInMinutes: number
   serviceMessagesStaleDays: number
-  serviceNowUrl: string
+  supportEmail: string
+  supportCJSMEmail: string
   suggestedPasswordNumWords: number
   suggestedPasswordMinWordLength: number
   suggestedPasswordMaxWordLength: number
@@ -69,7 +70,8 @@ const getConfig = (): UserServiceConfig => ({
   rememberEmailAddressCookieName: "LOGIN_EMAIL",
   rememberEmailAddressMaxAgeInMinutes: parseInt(process.env.REMEMBER_EMAIL_MAX_AGE ?? "1440", 10),
   serviceMessagesStaleDays: parseInt(process.env.SERVICE_MESSAGES_STALE_DAYS ?? "30", 10),
-  serviceNowUrl: "https://mojprod.service-now.com/",
+  supportEmail: process.env.SUPPORT_EMAIL ?? "moj-bichard7@madetech.com",
+  supportCJSMEmail: process.env.SUPPORT_CJSM_EMAIL ?? "moj-bichard7@madetech.cjsm.net",
   suggestedPasswordNumWords: 3,
   suggestedPasswordMinWordLength: 3,
   suggestedPasswordMaxWordLength: 8,

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -2,23 +2,39 @@ import ContactLink from "components/ContactLink"
 import GridColumn from "components/GridColumn"
 import GridRow from "components/GridRow"
 import Layout from "components/Layout"
+import Link from "components/Link"
 import Paragraph from "components/Paragraph"
 import Head from "next/head"
+
+const handleBack = (e: React.MouseEvent<HTMLElement>) => {
+  e.preventDefault()
+  window.history.back()
+}
 
 const Custom500 = () => (
   <>
     <Head>
-      <title>{"Sorry, there is a problem with the service"}</title>
+      <title>{"Sorry, there is a problem with Bichard"}</title>
     </Head>
     <Layout>
       <GridRow>
         <GridColumn width="two-thirds">
-          <h1 className="govuk-heading-xl">{"Sorry, there is a problem with the service"}</h1>
+          <h1 className="govuk-heading-xl">{"Sorry, there is a problem with Bichard"}</h1>
 
-          <Paragraph>{"Try again later."}</Paragraph>
+          <Paragraph>{"Please try the following"}</Paragraph>
+          <ol>
+            <li>
+              <Link href="#" onClick={handleBack}>
+                {"Click here to try the previous page again"}
+              </Link>
+            </li>
+            <li>
+              <Link href="/">{"Click here to go to the main login page"}</Link>
+            </li>
+          </ol>
           <Paragraph>
             <ContactLink>{"Contact support"}</ContactLink>
-            {" if you have repeated problems with the service."}
+            {" if you have repeated problems with Bichard."}
           </Paragraph>
         </GridColumn>
       </GridRow>

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -1,9 +1,11 @@
 import Accordion from "components/Accordion"
 import AccordionItem from "components/AccordionItem"
-import ServiceMessages from "components/ServiceMessages"
+import GridColumn from "components/GridColumn"
+import GridRow from "components/GridRow"
 import Layout from "components/Layout"
 import Link from "components/Link"
 import Paragraph from "components/Paragraph"
+import ServiceMessages from "components/ServiceMessages"
 import config from "lib/config"
 import getConnection from "lib/getConnection"
 import Head from "next/head"
@@ -12,9 +14,6 @@ import ServiceMessage from "types/ServiceMessage"
 import getServiceMessages from "useCases/getServiceMessages"
 import logger from "utils/logger"
 import faqJSON from "../faqs.json"
-import React from "react"
-import GridColumn from "components/GridColumn"
-import GridRow from "components/GridRow"
 
 interface faqJson {
   lastUpdated: string
@@ -63,11 +62,6 @@ const faq = ({ faqJson, serviceMessages }: Props) => {
               {"Frequently Asked Questions"}
             </h1>
 
-            <div data-test="faq_last-updated" className="govuk-hint">
-              {"Last Updated: "}
-              {faqJson.lastUpdated}
-            </div>
-
             <Paragraph>
               {
                 "Before contacting support, please check to see if your query is already answered by the information below."
@@ -85,7 +79,7 @@ const faq = ({ faqJson, serviceMessages }: Props) => {
             <h3 className="govuk-heading-m">{"Still need help?"}</h3>
             <Paragraph>
               {"If your query isn't answered by the above information, then you can "}
-              <Link href={config.serviceNowUrl}>{"raise a ticket with the service desk"}</Link>
+              <Link href={`mailto:${config.supportEmail}`}>{"contact the Bichard team for support"}</Link>
               {"."}
             </Paragraph>
           </GridColumn>

--- a/src/pages/feedback/index.tsx
+++ b/src/pages/feedback/index.tsx
@@ -99,7 +99,7 @@ const ShareFeedback = ({ csrfToken, currentUser, errorMessage, successMessage }:
                 {"Please keep in mind that if you are experiencing any issues, you should either check our "}
                 <ContactLink>{"FAQ page"}</ContactLink>
                 {" or "}
-                <Link href={config.serviceNowUrl}>{"raise a ticket with the service desk"}</Link>
+                <Link href={`mailto:${config.supportEmail}`}>{"contact support"}</Link>
                 {". Any issues raised via this page will not be handled."}
               </Paragraph>
             </div>

--- a/src/useCases/postFeedback.ts
+++ b/src/useCases/postFeedback.ts
@@ -4,7 +4,7 @@ import PromiseResult from "types/PromiseResult"
 import logger from "utils/logger"
 
 const postFeedback = (feedback: string, currentUserEmail?: string): PromiseResult<void> => {
-  const sendFeedbackTo = "kayleigh.derricutt@madetech.cjsm.net" // sorry Kayleigh :(
+  const sendFeedbackTo = config.supportCJSMEmail
 
   const emailer = getEmailer(sendFeedbackTo)
   const fromUser = currentUserEmail ? `User ${currentUserEmail}` : "An unknown user"

--- a/test/pages/__snapshots__/500.test.tsx.snap
+++ b/test/pages/__snapshots__/500.test.tsx.snap
@@ -107,13 +107,31 @@ exports[`should render the component and match the snapshot 1`] = `
           <h1
             class="govuk-heading-xl"
           >
-            Sorry, there is a problem with the service
+            Sorry, there is a problem with Bichard
           </h1>
           <p
             class="govuk-body"
           >
-            Try again later.
+            Please try the following
           </p>
+          <ol>
+            <li>
+              <a
+                class="govuk-link"
+                href="#"
+              >
+                Click here to try the previous page again
+              </a>
+            </li>
+            <li>
+              <a
+                class="govuk-link"
+                href="/"
+              >
+                Click here to go to the main login page
+              </a>
+            </li>
+          </ol>
           <p
             class="govuk-body"
           >
@@ -123,7 +141,7 @@ exports[`should render the component and match the snapshot 1`] = `
             >
               Contact support
             </a>
-             if you have repeated problems with the service.
+             if you have repeated problems with Bichard.
           </p>
         </div>
       </div>


### PR DESCRIPTION
When we restart the backend the server-side user session being cleared can cause the legacy app to raise a 500 error.
This adds a simple back button to the error page to prompt the user to try again (as it will create a new session) and which should make the user experience a bit less frustrating.

It also updates the support links from ServiceNow to the Bichard support email