### PR TITLE
Fix link to what's new in Help docs

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -11,6 +11,7 @@ interface Props {
   rel?: string
   title?: string
   onClick?: (e: React.MouseEvent<HTMLElement>) => void
+  target?: string
 }
 
 const Link = ({
@@ -22,7 +23,8 @@ const Link = ({
   id,
   rel,
   title,
-  onClick
+  onClick,
+  target
 }: Props) => (
   <a
     data-test={dataTest}
@@ -32,6 +34,7 @@ const Link = ({
     rel={rel}
     title={title}
     onClick={onClick}
+    target={target}
   >
     {children}
   </a>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -214,7 +214,7 @@ const Home = ({
             <NotificationBanner heading="There are new features available on new Bichard">
               <Paragraph>
                 {"View "}
-                <Link basePath={false} href={"/help/whats-new"}>
+                <Link basePath={false} href={"/help/whats-new/"} target={"_blank"}>
                   {"the help guidance for new features"}
                 </Link>
                 {"."}


### PR DESCRIPTION
And make it open in a new tab so it's consistent with new UI.

https://dsdmoj.atlassian.net/browse/BICAWS7-3438